### PR TITLE
Add tclXchannelfd.c to configure

### DIFF
--- a/configure
+++ b/configure
@@ -5440,7 +5440,7 @@ done
 	tclXinit.c    tclXkeylist.c tclXlib.c      tclXlist.c
 	tclXmath.c    tclXmsgcat.c  tclXprocess.c  tclXprofile.c
 	tclXselect.c  tclXsignal.c  tclXstring.c   tclXsocket.c
-	tclXutil.c    tclXoscmds.c  tclXlgets.c
+	tclXutil.c    tclXoscmds.c  tclXlgets.c    tclXchannelfd.c
 "
     for i in $vars; do
 	case $i in


### PR DESCRIPTION
If user does not execute autoconf, it is necessary to add tclXchannelfd.c to configure.