### PR TITLE
add "make test" to travis and fix test fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,10 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install tcl-tk; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install tcl8.6-dev -y; fi
-  
+
 script:
   - autoreconf -vi
   - if [ -f /usr/local/opt/tcl-tk/lib/tclConfig.sh ]; then ./configure --with-tcl=/usr/local/opt/tcl-tk/lib --prefix=/usr/local; else ./configure; fi
   - make
   - sudo make install
+  - make test

--- a/generic/tclXutil.c
+++ b/generic/tclXutil.c
@@ -932,6 +932,9 @@ TclX_RestoreResultErrorInfo (Tcl_Interp *interp, Tcl_Obj *saveObjPtr)
     Tcl_SetVar2Ex(interp, ERRORCODE, NULL, saveObjv[2], TCL_GLOBAL_ONLY);
     Tcl_SetVar2Ex(interp, ERRORINFO, NULL, saveObjv[1], TCL_GLOBAL_ONLY);
 
+    Tcl_ResetResult(interp);
+    Tcl_AppendObjToErrorInfo(interp, saveObjv[1]);
+    Tcl_SetObjErrorCode(interp, saveObjv[2]);
     Tcl_SetObjResult (interp, saveObjv[0]);
 
     ((Interp *)interp)->flags |= flags;

--- a/tests/all.tcl
+++ b/tests/all.tcl
@@ -37,7 +37,7 @@ if {[llength $::tcltest::matchFiles] > 0} {
 set timeCmd {clock format [clock seconds]}
 puts stdout "Tests began at [eval $timeCmd]"
 
-package require Tclx 8.4
+package require Tclx 8.6
 
 # source each of the specified tests
 foreach file [lsort [::tcltest::getMatchingFiles]] {

--- a/tests/cmdtrace.test
+++ b/tests/cmdtrace.test
@@ -91,7 +91,7 @@ Test cmdtrace-1.2 {command trace: not evaluated, truncated} {
     DoStuff4
     cmdtrace off
     GetTrace $cmdtraceFH
-} 0 "DoStuff4\\n
+} 0 "DoStuff4
   DoStuff3
     DoStuff2
       DoStuff1
@@ -100,9 +100,9 @@ Test cmdtrace-1.2 {command trace: not evaluated, truncated} {
           set foo \[replicate \"-TheString-\" 10\]
           set baz \$foo
           set wap 1
-          if {\$wap} {\\n        set wap 0\\n    } else \{\\n        set wap 1...
+          if {\$wap} {\\n        set wap 0\\n    } else {\\n        set wap 1...
             set wap 0
-cmdtrace off\\n
+cmdtrace off
 "
 
 Test cmdtrace-1.3 {command trace: evaluated, not truncated} {
@@ -131,7 +131,7 @@ Test cmdtrace-1.4 {command trace: not evaluated, not truncated} {
     DoStuff4
     cmdtrace off
     GetTrace $cmdtraceFH
-} 0 {DoStuff4\n
+} 0 {DoStuff4
   DoStuff3
     DoStuff2
       DoStuff1
@@ -142,7 +142,7 @@ Test cmdtrace-1.4 {command trace: not evaluated, not truncated} {
           set wap 1
           if {$wap} {\n        set wap 0\n    } else {\n        set wap 1\n    }
             set wap 0
-cmdtrace off\n
+cmdtrace off
 }
 
 Test cmdtrace-2.1 {command trace argument error checking} {
@@ -187,8 +187,7 @@ Test cmdtrace-3.1 {command trace argument error checking} {
     cmdtrace off
     lappend traceout $errorInfo $errorCode
     set traceout
-} 0 [list {CD {{DoStuff4
-}} DoStuff4 {}} \
+} 0 [list {CD DoStuff4 DoStuff4 {}} \
 {CD DoStuff3 DoStuff3 {}} \
 {CD DoStuff2 DoStuff2 {}} \
 {CD DoStuff1 DoStuff1 {}} \
@@ -207,8 +206,7 @@ Test cmdtrace-3.1 {command trace argument error checking} {
         set wap 1
     }}} {}} \
 {CD {{set wap 0}} {{set wap 0}} {}} \
-{CD {{cmdtrace off
-}} {{cmdtrace off}} {}}\
+{CD {{cmdtrace off}} {{cmdtrace off}} {}}\
 ERRORINFO \
 ERRORCODE]
 

--- a/tests/profile.test
+++ b/tests/profile.test
@@ -164,7 +164,7 @@ proc listRemovePrecomp {args} {
 # Test of normal procedure calls.
 #
 proc ProcA2 {} {ProcB2; set j 1; incr j; set k 1}
-proc ProcB2 {} {ProcC2; concat a b; ProcC2; list a b; list c d}
+proc ProcB2 {} {ProcC2; join a b; ProcC2; list a b; list c d}
 proc ProcC2 {} {expr 1+1}
 
 test profile-2.1 {profile count tests} {
@@ -186,7 +186,7 @@ test profile-2.2 {profile count tests} {
 	{{::ProcA2 <global>} 1} \
 	{{::ProcB2 ::ProcA2 <global>} 1} \
 	{{::ProcC2 ::ProcB2 ::ProcA2 <global>} 2} \
-	{{::concat ::ProcB2 ::ProcA2 <global>} 1} \
+	{{::join ::ProcB2 ::ProcA2 <global>} 1} \
 	{{::list ::ProcB2 ::ProcA2 <global>} 2} \
 	{{::profile <global>} 1}]
 
@@ -209,7 +209,7 @@ test profile-2.4 {profile count tests} {
 	{{::ProcA2 <global>} 1} \
 	{{::ProcB2 ::ProcA2 <global>} 1} \
 	{{::ProcC2 ::ProcB2 ::ProcA2 <global>} 2} \
-	{{::concat ::ProcB2 ::ProcA2 <global>} 1} \
+	{{::join ::ProcB2 ::ProcA2 <global>} 1} \
 	{{::list ::ProcB2 ::ProcA2 <global>} 2} \
 	{{::profile <global>} 1}]
 
@@ -220,7 +220,7 @@ test profile-2.4 {profile count tests} {
 proc ProcA3 {} {ProcB3}
 proc ProcB3 {} {ProcC3}
 proc ProcC3 {} {uplevel ProcD3; ProcD3}
-proc ProcD3 {} {set a 1; incr a; concat a b}
+proc ProcD3 {} {set a 1; incr a; join a b}
 
 test profile-3.1 {profile count tests} {
     profile on
@@ -245,8 +245,8 @@ test profile-3.2 {profile count tests} {
 	{{::ProcC3 ::ProcB3 ::ProcA3 <global>} 1} \
 	{{::ProcD3 ::ProcB3 ::ProcA3 <global>} 1} \
 	{{::ProcD3 ::ProcC3 ::ProcB3 ::ProcA3 <global>} 1} \
-	{{::concat ::ProcD3 ::ProcB3 ::ProcA3 <global>} 1} \
-	{{::concat ::ProcD3 ::ProcC3 ::ProcB3 ::ProcA3 <global>} 1} \
+	{{::join ::ProcD3 ::ProcB3 ::ProcA3 <global>} 1} \
+	{{::join ::ProcD3 ::ProcC3 ::ProcB3 ::ProcA3 <global>} 1} \
 	{{::profile <global>} 1} \
 	{{::uplevel ::ProcC3 ::ProcB3 ::ProcA3 <global>} 1}]
 
@@ -272,8 +272,8 @@ test profile-3.4 {profile count tests} {
 	{{::ProcC3 ::ProcB3 ::ProcA3 <global>} 1} \
 	{{::ProcD3 ::ProcC3 ::ProcB3 ::ProcA3 <global>} 1} \
 	{{::ProcD3 ::uplevel ::ProcC3 ::ProcB3 ::ProcA3 <global>} 1} \
-	{{::concat ::ProcD3 ::ProcC3 ::ProcB3 ::ProcA3 <global>} 1} \
-	{{::concat ::ProcD3 ::uplevel ::ProcC3 ::ProcB3 ::ProcA3 <global>} 1} \
+	{{::join ::ProcD3 ::ProcC3 ::ProcB3 ::ProcA3 <global>} 1} \
+	{{::join ::ProcD3 ::uplevel ::ProcC3 ::ProcB3 ::ProcA3 <global>} 1} \
 	{{::profile <global>} 1} \
 	{{::uplevel ::ProcC3 ::ProcB3 ::ProcA3 <global>} 1}]
 
@@ -349,7 +349,7 @@ proc ProcC5a {} {ProcD5}
 proc ProcC5b {} {ProcD5}
 proc ProcC5c {} {ProcD5}
 proc ProcC5d {} {ProcD5}
-proc ProcD5 {} {concat a b; list c d}
+proc ProcD5 {} {join a b; list c d}
 
 test profile-5.1 {profile count tests} {tclx_test_eval} {
     profile on
@@ -384,10 +384,10 @@ test profile-5.2 {profile count tests} {tclx_test_eval} {
 	{{::ProcD5 ::ProcC5b <global>} 1} \
 	{{::ProcD5 ::ProcC5c ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
 	{{::ProcD5 ::ProcC5d ::ProcA5 <global>} 1} \
-	{{::concat ::ProcD5 ::ProcC5a ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
-	{{::concat ::ProcD5 ::ProcC5b <global>} 1} \
-	{{::concat ::ProcD5 ::ProcC5c ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
-	{{::concat ::ProcD5 ::ProcC5d ::ProcA5 <global>} 1} \
+	{{::join ::ProcD5 ::ProcC5a ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
+	{{::join ::ProcD5 ::ProcC5b <global>} 1} \
+	{{::join ::ProcD5 ::ProcC5c ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
+	{{::join ::ProcD5 ::ProcC5d ::ProcA5 <global>} 1} \
 	{{::list ::ProcD5 ::ProcC5a ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
 	{{::list ::ProcD5 ::ProcC5b <global>} 1} \
 	{{::list ::ProcD5 ::ProcC5c ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
@@ -428,10 +428,10 @@ test profile-5.4 {profile count tests} {tclx_test_eval} {
 	{{::ProcD5 ::ProcC5b ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
 	{{::ProcD5 ::ProcC5c ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
 	{{::ProcD5 ::ProcC5d ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
-	{{::concat ::ProcD5 ::ProcC5a ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
-	{{::concat ::ProcD5 ::ProcC5b ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
-	{{::concat ::ProcD5 ::ProcC5c ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
-	{{::concat ::ProcD5 ::ProcC5d ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
+	{{::join ::ProcD5 ::ProcC5a ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
+	{{::join ::ProcD5 ::ProcC5b ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
+	{{::join ::ProcD5 ::ProcC5c ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
+	{{::join ::ProcD5 ::ProcC5d ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
 	{{::list ::ProcD5 ::ProcC5a ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
 	{{::list ::ProcD5 ::ProcC5b ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
 	{{::list ::ProcD5 ::ProcC5c ::tclx_test_eval ::ProcB5 ::ProcA5 <global>} 1} \
@@ -703,7 +703,7 @@ EatTime                           4        800         10
 #
 namespace eval Prof {
     proc NSProcA2 {} {NSProcB2; set j 1; incr j; set k 1}
-    proc NSProcB2 {} {NSProcC2; concat a b; NSProcC2; list a b; list c d}
+    proc NSProcB2 {} {NSProcC2; join a b; NSProcC2; list a b; list c d}
     proc NSProcC2 {} {expr 1+1}
 }
 
@@ -726,7 +726,7 @@ test profile-12.2 {profile namespace tests} {
 	{{::Prof::NSProcA2 <global>} 1} \
 	{{::Prof::NSProcB2 ::Prof::NSProcA2 <global>} 1} \
 	{{::Prof::NSProcC2 ::Prof::NSProcB2 ::Prof::NSProcA2 <global>} 2} \
-	{{::concat ::Prof::NSProcB2 ::Prof::NSProcA2 <global>} 1} \
+	{{::join ::Prof::NSProcB2 ::Prof::NSProcA2 <global>} 1} \
 	{{::list ::Prof::NSProcB2 ::Prof::NSProcA2 <global>} 2} \
 	{{::profile <global>} 1}]
 
@@ -749,7 +749,7 @@ test profile-12.4 {profile namespace tests} {
 	{{::Prof::NSProcA2 <global>} 1} \
 	{{::Prof::NSProcB2 ::Prof::NSProcA2 <global>} 1} \
 	{{::Prof::NSProcC2 ::Prof::NSProcB2 ::Prof::NSProcA2 <global>} 2} \
-	{{::concat ::Prof::NSProcB2 ::Prof::NSProcA2 <global>} 1} \
+	{{::join ::Prof::NSProcB2 ::Prof::NSProcA2 <global>} 1} \
 	{{::list ::Prof::NSProcB2 ::Prof::NSProcA2 <global>} 2} \
 	{{::profile <global>} 1}]
 

--- a/tests/string.test
+++ b/tests/string.test
@@ -46,11 +46,9 @@ Test string-1.6 {cindex tests} {
     cindex ABCDEFG len-3
 } 0 {E}
 
-Test string-1.7 {cindex tests} {
+tcltest::test string-1.7 {cindex tests} -body {
     cindex ABCDEFG lenx-3
-} 1 "syntax error in expression \"7x-3\"[expr {
-    ($tcl_version>8.3) ? ": extra tokens at end of expression" : ""
-}]"
+} -returnCodes 1 -match glob -result "*in expression \"7x-3\"*"
 
 Test string-1.8 {cindex tests} {
     cindex ABCDEFG
@@ -142,12 +140,10 @@ Test string-3.7 {crange tests} {
     crange ABCD len-3 end-1
 } 0 {BC}
 
-Test string-3.8 {crange tests} {
+tcltest::test string-3.8 {crange tests} -body {
     # 8.4+ enhanced the error return from expressions
     crange ABCD lenx-3 end-1
-}  1 "syntax error in expression \"4x-3\"[expr {
-    ($tcl_version>8.3) ? ": extra tokens at end of expression" : ""
-}]"
+}  -returnCodes 1 -match glob -result "*in expression \"4x-3\"*"
 
 Test string-3.9 {crange tests} {
     set text .tex


### PR DESCRIPTION
Add "make test" to file ".travis.yml".

Use "package require Tclx 8.6" in tests/all.tcl
Fix "try_eval" test fail by using Tcl_AppendObjToErrorInfo and Tcl_SetObjErrorCode.
Fix "profile" test fail by replace command "concat" with "join".
Fix "string.test" fail by using "-match glob"