### PR TITLE
TIP #571: Fix the TclX's profiler to be conform with the NRE

### DIFF
--- a/generic/tclXprofile.c
+++ b/generic/tclXprofile.c
@@ -571,6 +571,10 @@ ProfTraceRoutine (ClientData  clientData,
     if (cmd == NULL)
         panic (PROF_PANIC, 4);
 
+    //TIP #571: We don' want to profile the tailcall itself. As it can only be called in a procedure/lambda context
+    if ( ! strcmp((*objv)->bytes, "tailcall") ) {
+        return TCL_OK;
+    }
     /*
      * Save current state information.
      */


### PR DESCRIPTION
The profiler is now compatible with the NRE feature. 