### PR TITLE
Fix configure.ac compatibility with Clang 16

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -193,10 +193,11 @@ WIFEXITED(x);	/* Generates compiler error if WIFEXITED uses an int. */
     
     AC_MSG_CHECKING(checking to see what 'times' returns)
     AC_TRY_RUN([
+#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/times.h>
 #include <unistd.h>
-main() {
+int main(void) {
     struct tms cpu;
     times(&cpu);
     sleep(2);
@@ -269,7 +270,8 @@ main() {
     
     AC_CHECK_FUNC(catgets,
     	[AC_MSG_CHECKING([catclose return value])
-    	 AC_TRY_COMPILE([#include <nl_types.h>], [
+    	 AC_TRY_COMPILE([#include <stdlib.h>
+         #include <nl_types.h>], [
     	    if (catclose ((nl_catd) 0) == 0) exit (0);],
     	    AC_MSG_RESULT(ok), [
     	    AC_MSG_RESULT([broken catclose return type])

--- a/tclconfig/tcl.m4
+++ b/tclconfig/tcl.m4
@@ -2525,7 +2525,8 @@ AC_DEFUN([TEA_TIME_HANDLER], [
     # (like convex) have timezone functions, etc.
     #
     AC_CACHE_CHECK([long timezone variable], tcl_cv_timezone_long, [
-	AC_TRY_COMPILE([#include <time.h>],
+	AC_TRY_COMPILE([#include <stdlib.h>
+            #include <time.h>],
 	    [extern long timezone;
 	    timezone += 1;
 	    exit (0);],
@@ -2537,7 +2538,8 @@ AC_DEFUN([TEA_TIME_HANDLER], [
 	# On some systems (eg IRIX 6.2), timezone is a time_t and not a long.
 	#
 	AC_CACHE_CHECK([time_t timezone variable], tcl_cv_timezone_time, [
-	    AC_TRY_COMPILE([#include <time.h>],
+	    AC_TRY_COMPILE([#include <stdlib.h>
+                #include <time.h>],
 		[extern time_t timezone;
 		timezone += 1;
 		exit (0);],
@@ -2574,7 +2576,7 @@ AC_DEFUN([TEA_BUGGY_STRTOD], [
 	    AC_TRY_RUN([
 		#include <stdlib.h>
 		extern double strtod();
-		int main() {
+		int main(void) {
 		    char *infString="Inf", *nanString="NaN", *spaceString=" ";
 		    char *term;
 		    double value;


### PR DESCRIPTION
Clang 16 makes -Wimplicit-function-declaration and -Wimplicit-int errors by default.

Unfortunately, this can lead to misconfiguration or miscompilation of software as configure tests may then return the wrong result.

We also fix -Wstrict-prototypes while here as it's easy to do and it prepares us for C23.

For more information, see LWN.net [0] or LLVM's Discourse [1], the Gentoo wiki [2], or the (new) c-std-porting mailing list [3].

[0] https://lwn.net/Articles/913505/
[1] https://discourse.llvm.org/t/configure-script-breakage-with-the-new-werror-implicit-function-declaration/65213 [2] https://wiki.gentoo.org/wiki/Modern_C_porting
[3] hosted at lists.linux.dev.

Bug: https://bugs.gentoo.org/881713
Signed-off-by: Sam James <sam@gentoo.org>