### PR TITLE
Silencing gcc-11 warnings

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -254,6 +254,7 @@ main() {
     
     AC_CHECK_FUNC(inet_aton, , [AC_DEFINE(NO_INET_ATON)])
     AC_CHECK_FUNC(gethostname, , [AC_DEFINE(NO_GETHOSTNAME)])
+    AC_CHECK_FUNCS([rresvport])
     
     #-------------------------------------------------------------------------
     # Check for additional libraries the Tcl/Tk does not check for.

--- a/generic/tclXfcntl.c
+++ b/generic/tclXfcntl.c
@@ -200,8 +200,12 @@ GetFcntlAttr (Tcl_Interp *interp, Tcl_Channel channel, int mode, int attrib)
         value = (optValue == TCLX_BUFFERING_LINE);
         break;
       case ATTR_KEEPALIVE:
-        if (TclXOSgetsockopt (interp, channel, SO_KEEPALIVE, &value) != TCL_OK)
+        {
+        socklen_t len;
+        if (TclXOSgetsockopt (interp, channel, SO_KEEPALIVE, &len) != TCL_OK)
             return TCL_ERROR;
+        value = len;
+        }
         break;
       default:
         Tcl_Panic ("bug in fcntl get attrib");

--- a/generic/tclXhandles.c
+++ b/generic/tclXhandles.c
@@ -20,6 +20,9 @@
 
 #include "tclExtdInt.h"
 
+#include <stdint.h>
+#include <inttypes.h>
+
 /*
  * Variable set to contain the alignment factor (in bytes) for this machine.
  * It is set on the first table initialization.
@@ -539,7 +542,7 @@ TclX_HandleFree (void_pt headerPtr, void_pt entryPtr)
 
     entryHdrPtr = HEADER_AREA (entryPtr);
     if (entryHdrPtr->freeLink != ALLOCATED_IDX)
-        Tcl_Panic ("Tcl_HandleFree: entry not allocated %x\n", entryHdrPtr);
+        Tcl_Panic ("Tcl_HandleFree: entry not allocated %" PRIxPTR "\n", entryHdrPtr);
 
     entryHdrPtr->freeLink = tblHdrPtr->freeHeadIdx;
     tblHdrPtr->freeHeadIdx =

--- a/generic/tclXkeylist.c
+++ b/generic/tclXkeylist.c
@@ -17,6 +17,7 @@
  */
 
 #include "tclExtdInt.h"
+#include <stdint.h>
 
 /*
  * Keyed lists are stored as arrays recursively defined objects.  The data
@@ -338,7 +339,7 @@ DeleteKeyedListEntry (keylIntObj_t *keylIntPtr, int entryIdx)
     if (keylIntPtr->hashTbl != NULL) {
 	Tcl_HashEntry *entryPtr;
 	Tcl_HashSearch search;
-	int nidx;
+	intptr_t nidx;
 
 	entryPtr = Tcl_FindHashEntry(keylIntPtr->hashTbl,
 		keylIntPtr->entries [entryIdx].key);
@@ -354,7 +355,7 @@ DeleteKeyedListEntry (keylIntObj_t *keylIntPtr, int entryIdx)
 	 */
 	for (entryPtr = Tcl_FirstHashEntry(keylIntPtr->hashTbl, &search);
 	     entryPtr != NULL; entryPtr = Tcl_NextHashEntry(&search)) {
-	    nidx = (int) Tcl_GetHashValue(entryPtr);
+	    nidx = (intptr_t) Tcl_GetHashValue(entryPtr);
 	    if (nidx > entryIdx) {
 		Tcl_SetHashValue(entryPtr, (ClientData) (uintptr_t) (nidx - 1));
 	    }
@@ -394,7 +395,8 @@ FindKeyedListEntry (keylIntObj_t *keylIntPtr,
                     char	    **nextSubKeyPtr)
 {
     char *keySeparPtr;
-    int keyLen, findIdx = -1;
+    int keyLen;
+    intptr_t findIdx = -1;
 
     keySeparPtr = strchr (key, '.');
     if (keySeparPtr != NULL) {
@@ -416,7 +418,7 @@ FindKeyedListEntry (keylIntObj_t *keylIntPtr,
 	}
 	entryPtr = Tcl_FindHashEntry(keylIntPtr->hashTbl, key);
 	if (entryPtr != NULL) {
-	    findIdx = (int) Tcl_GetHashValue(entryPtr);
+	    findIdx = (intptr_t) Tcl_GetHashValue(entryPtr);
 	}
 	if (keySeparPtr != NULL) {
 	    key[keyLen] = tmp;

--- a/generic/tclXsignal.c
+++ b/generic/tclXsignal.c
@@ -463,7 +463,7 @@ SetSignalState (int signalNum, signalProcPtr_t sigFunc, int restart)
  *-----------------------------------------------------------------------------
  */
 static int
-BlockSignals (Tcl_Interp *interp, int action, unsigned char signals[])
+BlockSignals (Tcl_Interp *interp, int action, unsigned char signals[MAXSIG])
 {
 #ifndef NO_SIGACTION
     int      signalNum;

--- a/unix/tclXunixDup.c
+++ b/unix/tclXunixDup.c
@@ -17,6 +17,7 @@
  */
 
 #include "tclExtdInt.h"
+#include <stdint.h>
 
 
 /*-----------------------------------------------------------------------------
@@ -75,7 +76,8 @@ TclXOSDupChannel(Tcl_Interp *interp, Tcl_Channel srcChannel, int mode, char *tar
     ClientData handle;
     const Tcl_ChannelType *channelType;
     Tcl_Channel newChannel = NULL;
-    int srcFileNum, newFileNum = -1;
+    intptr_t srcFileNum;
+    int newFileNum = -1;
 
     /*
      * On Unix, the channels we can dup share the same file for the read and
@@ -86,7 +88,7 @@ TclXOSDupChannel(Tcl_Interp *interp, Tcl_Channel srcChannel, int mode, char *tar
     } else {
         Tcl_GetChannelHandle (srcChannel, TCL_WRITABLE, &handle);
     }
-    srcFileNum = (int) handle;
+    srcFileNum = (intptr_t) handle;
     channelType = Tcl_GetChannelType (srcChannel);
 
     /*

--- a/unix/tclXunixId.c
+++ b/unix/tclXunixId.c
@@ -444,7 +444,7 @@ IdHost (Tcl_Interp *interp, int objc, Tcl_Obj*CONST objv[])
 #endif
     char hostNameBuf[MAXHOSTNAMELEN];
 
-    if (objc != 2)
+	if (objc != 2)
         return TclX_WrongArgs (interp, objv [0], "host");
 
 	if (gethostname (hostNameBuf, MAXHOSTNAMELEN) < 0) {

--- a/unix/tclXunixOS.c
+++ b/unix/tclXunixOS.c
@@ -23,6 +23,7 @@
 
 #include "tclExtdInt.h"
 
+#include <stdint.h>
 #ifndef NO_GETPRIORITY
 #include <sys/resource.h>
 #endif
@@ -113,7 +114,7 @@ ChannelToFnum (Tcl_Channel channel, int direction)
             return -1;
 	}
     }
-    return (int) handle;
+    return (intptr_t) handle;
 }
 
 /*-----------------------------------------------------------------------------
@@ -401,7 +402,7 @@ TclXOSsystem (Tcl_Interp *interp, char *command, int *exitCode)
     if (pid == 0) {
         close (errPipes [0]);
         execl ("/bin/sh", "sh", "-c", command, (char *) NULL);
-        write (errPipes [1], &errno, sizeof (errno));
+        if(write (errPipes [1], &errno, sizeof (errno))) {};
         _exit (127);
     }
 
@@ -918,8 +919,9 @@ TclXOSgetpeername (Tcl_Interp *interp, Tcl_Channel channel, void *sockaddr, sock
 int
 TclXOSgetsockname (Tcl_Interp *interp, Tcl_Channel channel, void *sockaddr, int sockaddrSize)
 {
+    socklen_t siz = sockaddrSize;
     if (getsockname (ChannelToFnum (channel, 0),
-		(struct sockaddr *) sockaddr, &sockaddrSize) < 0) {
+		(struct sockaddr *) sockaddr, &siz) < 0) {
 	TclX_AppendObjResult (interp, Tcl_GetChannelName (channel), ": ",
 		Tcl_PosixError (interp), (char *) NULL);
 	return TCL_ERROR;
@@ -943,7 +945,7 @@ TclXOSgetsockname (Tcl_Interp *interp, Tcl_Channel channel, void *sockaddr, int 
 int
 TclXOSgetsockopt (Tcl_Interp *interp, Tcl_Channel channel, int option, socklen_t *valuePtr)
 {
-    int valueLen = sizeof (*valuePtr);
+    socklen_t valueLen = sizeof (*valuePtr);
 
     if (getsockopt (ChannelToFnum (channel, 0), SOL_SOCKET, option, 
 		(void*) valuePtr, &valueLen) != 0) {
@@ -1385,7 +1387,7 @@ TclXOSGetSelectFnum (Tcl_Interp *interp, Tcl_Channel channel, int direction, int
                               (char *) NULL);
         return TCL_ERROR;
     }
-    *fnumPtr = (int) handle;
+    *fnumPtr = (intptr_t) handle;
     return TCL_OK;
 }
 

--- a/unix/tclXunixSock.c
+++ b/unix/tclXunixSock.c
@@ -194,10 +194,12 @@ TclX_ServerCreateCmd (ClientData clientData,
      * Allocate a reserved port if requested.
      */
     if (getReserved) {
+#ifdef HAVE_RRESVPORT
         int port;
         if (rresvport (&port) < 0)
             goto unixError;
         local.sin_port = port;
+#endif
     }
 
     /*


### PR DESCRIPTION
Nothing really problematic I think. I just silenced some warning from pointer to int, and signed /unsigned conversion.

Added a fix for musl: rresvport is not available on it