### PR TITLE
tclXunixOS.c: remove `floor()`/`ceil()` declarations

### DIFF
--- a/unix/tclXunixOS.c
+++ b/unix/tclXunixOS.c
@@ -38,18 +38,6 @@
 #endif
 
 /*
- * Cheat a little to avoid configure checking for floor and ceil being
- * This breaks with GNU libc headers...really should check with autoconf.
- */
-#ifndef __GNU_LIBRARY__
-extern
-double floor ();
-
-extern
-double ceil ();
-#endif
-
-/*
  * Prototypes of internal functions.
  */
 static int


### PR DESCRIPTION
tclExtdInt.h includes tclXunixPort.h and in turn math.h, which should already declare these functions (although maybe that was not the case when these declarations were first used in 8a45a2f783e39c1fc7c3ab184688f268e3ad8877).

These duplicate declarations also lack prototypes, which newer clang warns about by default:
```
./unix/tclXunixOS.c:47:8: warning: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C2x, conflicting with a previous declaration [-Wdeprecated-non-prototype]
   47 | double floor ();
      |        ^
./unix/tclXunixOS.c:50:8: warning: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C2x, conflicting with a previous declaration [-Wdeprecated-non-prototype]
   50 | double ceil ();
      |        ^
```