### PR TITLE
Use prototypes in function declarations/definitions

### DIFF
--- a/compat/getopt.c
+++ b/compat/getopt.c
@@ -58,10 +58,10 @@ char	*optarg;		/* argument associated with option */
  *	Parse argc/argv argument vector.
  */
 int
-getopt(nargc, nargv, ostr)
-	int nargc;
-	char * const *nargv;
-	const char *ostr;
+getopt(
+	int nargc,
+	char * const *nargv,
+	const char *ostr)
 {
 	static char *place = EMSG;		/* option letter processing */
 	char *oli;				/* option letter list index */

--- a/compat/random.c
+++ b/compat/random.c
@@ -49,7 +49,7 @@
 
 #include <stdio.h>
 
-long random();
+long random(void);
 
 typedef unsigned int u_int;
 
@@ -243,10 +243,10 @@ srandom(x)
  * Returns a pointer to the old state.
  */
 char *
-initstate(seed, arg_state, n)
-	u_int seed;			/* seed for R.N.G. */
-	char *arg_state;		/* pointer to state array */
-	int n;				/* # bytes of state info */
+initstate(
+	u_int seed,			/* seed for R.N.G. */
+	char *arg_state,		/* pointer to state array */
+	int n)				/* # bytes of state info */
 {
 	register char *ostate = (char *)(&state[-1]);
 
@@ -306,8 +306,7 @@ initstate(seed, arg_state, n)
  * Returns a pointer to the old state information.
  */
 char *
-setstate(arg_state)
-	char *arg_state;
+setstate(char *arg_state)
 {
 	register long *new_state = (long *)arg_state;
 	register int type = new_state[0] % MAX_TYPES;
@@ -359,7 +358,7 @@ setstate(arg_state)
  * Returns a 31-bit random number.
  */
 long
-random()
+random(void)
 {
 	long i;
 

--- a/compat/rename.c
+++ b/compat/rename.c
@@ -6,8 +6,9 @@
  *
  */
 
-int rename(from,to)
-register char *from, *to;
+int rename(
+register char *from,
+register char *to)
 {
     (void) unlink(to);
     if (link(from, to) < 0)

--- a/generic/tclXkeylist.c
+++ b/generic/tclXkeylist.c
@@ -247,7 +247,7 @@ ValidateKey (Tcl_Interp *interp, char *key, int keyLen)
  *-----------------------------------------------------------------------------
  */
 static keylIntObj_t *
-AllocKeyedListIntRep ()
+AllocKeyedListIntRep (void)
 {
     keylIntObj_t *keylIntPtr;
 
@@ -674,7 +674,7 @@ UpdateStringOfKeyedList (Tcl_Obj *keylPtr)
  *-----------------------------------------------------------------------------
  */
 Tcl_Obj *
-TclX_NewKeyedListObj ()
+TclX_NewKeyedListObj (void)
 {
     Tcl_Obj *keylPtr = Tcl_NewObj ();
     keylIntObj_t *keylIntPtr = AllocKeyedListIntRep ();

--- a/generic/tclXprofile.c
+++ b/generic/tclXprofile.c
@@ -320,8 +320,7 @@ RecordData (profInfo_t  *infoPtr,
  *-----------------------------------------------------------------------------
  */
 static void
-PopEntry (infoPtr)
-    profInfo_t *infoPtr;
+PopEntry (profInfo_t *infoPtr)
 {
     profEntry_t *entryPtr = infoPtr->stackPtr;
 

--- a/generic/tclXsignal.c
+++ b/generic/tclXsignal.c
@@ -1572,7 +1572,7 @@ SignalCmdCleanUp (ClientData clientData, Tcl_Interp *interp)
  *-----------------------------------------------------------------------------
  */
 void
-TclX_SetupSigInt ()
+TclX_SetupSigInt (void)
 {
     signalProcPtr_t  actionFunc;
     int restart;

--- a/unix/tclXunixCmds.c
+++ b/unix/tclXunixCmds.c
@@ -106,8 +106,7 @@ TclX_TimesObjCmd (ClientData   clientData,
  *-----------------------------------------------------------------------------
  */
 void
-TclX_PlatformCmdsInit (interp)
-    Tcl_Interp *interp;
+TclX_PlatformCmdsInit (Tcl_Interp *interp)
 {
     Tcl_CreateObjCommand (interp,
 			  "chroot",

--- a/unix/tclXunixOS.c
+++ b/unix/tclXunixOS.c
@@ -319,7 +319,7 @@ TclXOSsleep (unsigned seconds)
  *-----------------------------------------------------------------------------
  */
 void
-TclXOSsync ()
+TclXOSsync (void)
 {
     sync ();
 }
@@ -1399,7 +1399,7 @@ TclXOSGetSelectFnum (Tcl_Interp *interp, Tcl_Channel channel, int direction, int
  *-----------------------------------------------------------------------------
  */
 int
-TclXOSHaveFlock ()
+TclXOSHaveFlock (void)
 {
 #ifdef F_SETLKW
     return TRUE;

--- a/unix/tclXunixSock.c
+++ b/unix/tclXunixSock.c
@@ -358,7 +358,7 @@ TclX_ServerInit (Tcl_Interp *interp)
     Tcl_CreateCommand (interp, "server_accept", TclX_ServerAcceptCmd,
                        (ClientData) NULL, (Tcl_CmdDeleteProc *) NULL);
     Tcl_CreateCommand (interp, "server_create", TclX_ServerCreateCmd,
-                       (ClientData) NULL, (void (*)()) NULL);
+                       (ClientData) NULL, (Tcl_CmdDeleteProc *) NULL);
 }
 
 /* vim: set ts=4 sw=4 sts=4 et : */

--- a/win/cattcl.c
+++ b/win/cattcl.c
@@ -33,9 +33,8 @@
  *-----------------------------------------------------------------------------
  */
 void
-TclX_SplitWinCmdLine (argcPtr, argvPtr)
-    int    *argcPtr;
-    char ***argvPtr;
+TclX_SplitWinCmdLine (int    *argcPtr;
+                      char ***argvPtr;
 {
     char   *args = GetCommandLine ();
     char **argvlist, *p;

--- a/win/tclXwinCmds.c
+++ b/win/tclXwinCmds.c
@@ -66,8 +66,7 @@ TclX_TimesObjCmd (ClientData  clientData,
  *-----------------------------------------------------------------------------
  */
 void
-TclX_PlatformCmdsInit (interp)
-    Tcl_Interp *interp;
+TclX_PlatformCmdsInit (Tcl_Interp *interp)
 {
     Tcl_CreateObjCommand (interp,
 			  "chroot",

--- a/win/tclXwinDup.c
+++ b/win/tclXwinDup.c
@@ -74,11 +74,10 @@ ConvertChannelName (Tcl_Interp *interp,
  *-----------------------------------------------------------------------------
  */
 Tcl_Channel
-TclXOSDupChannel (interp, srcChannel, mode, targetChannelId)
-    Tcl_Interp *interp;
-    Tcl_Channel srcChannel;
-    int         mode;
-    char       *targetChannelId;
+TclXOSDupChannel (Tcl_Interp *interp,
+                  Tcl_Channel srcChannel,
+                  int         mode,
+                  char       *targetChannelId)
 {
     Tcl_Channel newChannel = NULL;
     int direction;
@@ -175,9 +174,8 @@ TclXOSDupChannel (interp, srcChannel, mode, targetChannelId)
  *-----------------------------------------------------------------------------
  */
 Tcl_Channel
-TclXOSBindOpenFile (interp, fileNum)
-    Tcl_Interp *interp;
-    int         fileNum;
+TclXOSBindOpenFile (Tcl_Interp *interp,
+                    int         fileNum)
 {
     HANDLE fileHandle;
     int mode, isSocket;

--- a/win/tclXwinId.c
+++ b/win/tclXwinId.c
@@ -54,10 +54,9 @@ TclX_IdObjCmd (ClientData clientData,
  * id process
  */
 static int
-IdProcess (interp, objc, objv)
-    Tcl_Interp *interp;
-    int         objc;
-    Tcl_Obj    *CONST objv[];
+IdProcess (Tcl_Interp *interp,
+           int         objc,
+           Tcl_Obj    *CONST objv[])
 {
     Tcl_Obj *resultPtr = Tcl_GetObjResult (interp);
 
@@ -74,10 +73,9 @@ IdProcess (interp, objc, objv)
  * id host
  */
 static int
-IdHost (interp, objc, objv)
-    Tcl_Interp *interp;
-    int         objc;
-    Tcl_Obj    *CONST objv[];
+IdHost (Tcl_Interp *interp,
+        int         objc,
+        Tcl_Obj    *CONST objv[])
 {
     char hostName [TCL_RESULT_SIZE];
 
@@ -96,11 +94,10 @@ IdHost (interp, objc, objv)
 }
 
 static int
-TclX_IdObjCmd (clientData, interp, objc, objv)
-    ClientData  clientData;
-    Tcl_Interp *interp;
-    int         objc;
-    Tcl_Obj    *CONST objv[];
+TclX_IdObjCmd (ClientData  clientData,
+               Tcl_Interp *interp,
+               int         objc,
+               Tcl_Obj    *CONST objv[])
 {
     char *optionPtr;
 
@@ -139,8 +136,7 @@ TclX_IdObjCmd (clientData, interp, objc, objv)
  *-----------------------------------------------------------------------------
  */
 void
-TclX_IdInit (interp)
-    Tcl_Interp *interp;
+TclX_IdInit (Tcl_Interp *interp)
 {
     Tcl_CreateObjCommand (interp,
 			  "id",

--- a/win/tclXwinOS.c
+++ b/win/tclXwinOS.c
@@ -366,9 +366,8 @@ TclXOSincrpriority (Tcl_Interp *interp,
  *-----------------------------------------------------------------------------
  */
 int
-TclXOSpipe (interp, channels)
-    Tcl_Interp  *interp;
-    Tcl_Channel *channels;
+TclXOSpipe (Tcl_Interp  *interp,
+            Tcl_Channel *channels)
 {
     HANDLE readHandle, writeHandle;
     SECURITY_ATTRIBUTES sec;
@@ -437,7 +436,7 @@ TclXOSsleep (unsigned seconds)
  *-----------------------------------------------------------------------------
  */
 void
-TclXOSsync ()
+TclXOSsync (void)
 {
     _flushall ();
 }
@@ -1168,11 +1167,10 @@ TclXOSgetsockname (Tcl_Interp *interp,
  *-----------------------------------------------------------------------------
  */
 int
-TclXOSgetsockopt (interp, channel, option, valuePtr)
-    Tcl_Interp  *interp;
-    Tcl_Channel  channel;
-    int          option;
-    int         *valuePtr;
+TclXOSgetsockopt (Tcl_Interp  *interp,
+                  Tcl_Channel  channel,
+                  int          option,
+                  int         *valuePtr)
 {
     int valueLen = sizeof (*valuePtr);
     SOCKET sock;
@@ -1204,11 +1202,10 @@ TclXOSgetsockopt (interp, channel, option, valuePtr)
  *-----------------------------------------------------------------------------
  */
 int
-TclXOSsetsockopt (interp, channel, option, value)
-    Tcl_Interp  *interp;
-    Tcl_Channel  channel;
-    int          option;
-    int          value;
+TclXOSsetsockopt (Tcl_Interp  *interp,
+                  Tcl_Channel  channel,
+                  int          option,
+                  int          value)
 {
     int valueLen = sizeof (value);
     SOCKET sock;
@@ -1239,10 +1236,9 @@ TclXOSsetsockopt (interp, channel, option, value)
  *-----------------------------------------------------------------------------
  */
 int
-TclXOSchmod (interp, fileName, mode)
-    Tcl_Interp *interp;
-    char       *fileName;
-    int         mode;
+TclXOSchmod (Tcl_Interp *interp,
+             char       *fileName,
+             int         mode)
 {
 #if 0
     /*FIX:*/
@@ -1273,11 +1269,10 @@ TclXOSchmod (interp, fileName, mode)
  *-----------------------------------------------------------------------------
  */
 int
-TclXOSfchmod (interp, channel, mode, funcName)
-    Tcl_Interp *interp;
-    Tcl_Channel channel;
-    int         mode;
-    char       *funcName;
+TclXOSfchmod (Tcl_Interp *interp,
+              Tcl_Channel channel,
+              int         mode,
+              char       *funcName)
 {
 #if 0
   FIX:
@@ -1315,13 +1310,12 @@ TclXOSfchmod (interp, channel, mode, funcName)
  */
 
 int
-TclXOSChangeOwnGrpObj (interp, options, ownerStr, groupStr, files, funcName)
-    Tcl_Interp  *interp;
-    unsigned     options;
-    char        *ownerStr;
-    char        *groupStr;
-    Tcl_Obj	*files;
-    char       *funcName;
+TclXOSChangeOwnGrpObj (Tcl_Interp *interp,
+                       unsigned    options,
+                       char       *ownerStr,
+                       char       *groupStr,
+                       Tcl_Obj	  *files,
+                       char       *funcName)
 {
     return TclXNotAvailableError (interp, funcName);
 }
@@ -1348,13 +1342,12 @@ TclXOSChangeOwnGrpObj (interp, options, ownerStr, groupStr, files, funcName)
  *-----------------------------------------------------------------------------
  */
 int
-TclXOSFChangeOwnGrpObj (interp, options, ownerStr, groupStr, channelIds, funcName)
-    Tcl_Interp *interp;
-    unsigned    options;
-    char       *ownerStr;
-    char       *groupStr;
-    Tcl_Obj    *channelIds;
-    char       *funcName;
+TclXOSFChangeOwnGrpObj (Tcl_Interp *interp,
+                        unsigned    options,
+                        char       *ownerStr,
+                        char       *groupStr,
+                        Tcl_Obj    *channelIds,
+                        char       *funcName)
 {
     return TclXNotAvailableError (interp, funcName);
 }
@@ -1410,7 +1403,7 @@ TclXOSGetSelectFnum (Tcl_Interp *interp,
  *-----------------------------------------------------------------------------
  */
 int
-TclXOSHaveFlock ()
+TclXOSHaveFlock (void)
 {
     OVERLAPPED start;
 
@@ -1547,9 +1540,8 @@ LockUnlockSetup (Tcl_Interp     *interp,
  *-----------------------------------------------------------------------------
  */
 int
-TclXOSFlock (interp, lockInfoPtr)
-    Tcl_Interp     *interp;
-    TclX_FlockInfo *lockInfoPtr;
+TclXOSFlock (Tcl_Interp     *interp,
+             TclX_FlockInfo *lockInfoPtr)
 {
     HANDLE handle;
     DWORD flags, lengthHigh, lengthLow;
@@ -1609,9 +1601,8 @@ TclXOSFlock (interp, lockInfoPtr)
  *-----------------------------------------------------------------------------
  */
 int
-TclXOSFunlock (interp, lockInfoPtr)
-    Tcl_Interp     *interp;
-    TclX_FlockInfo *lockInfoPtr;
+TclXOSFunlock (Tcl_Interp     *interp,
+               TclX_FlockInfo *lockInfoPtr)
 {
     HANDLE handle;
     DWORD lengthHigh, lengthLow;
@@ -1659,10 +1650,9 @@ TclXOSFunlock (interp, lockInfoPtr)
  *-----------------------------------------------------------------------------
  */
 int
-TclXOSGetAppend (interp, channel, valuePtr)
-    Tcl_Interp *interp;
-    Tcl_Channel channel;
-    int        *valuePtr;
+TclXOSGetAppend (Tcl_Interp *interp,
+                 Tcl_Channel channel,
+                 int        *valuePtr)
 {
     return TclXNotAvailableError (interp,
                                   "append mode");
@@ -1682,10 +1672,9 @@ TclXOSGetAppend (interp, channel, valuePtr)
  *-----------------------------------------------------------------------------
  */
 int
-TclXOSSetAppend (interp, channel, value)
-    Tcl_Interp *interp;
-    Tcl_Channel channel;
-    int         value;
+TclXOSSetAppend (Tcl_Interp *interp,
+                 Tcl_Channel channel,
+                 int         value)
 {
     return TclXNotAvailableError (interp,
                                   "append mode");
@@ -1705,10 +1694,9 @@ TclXOSSetAppend (interp, channel, value)
  *-----------------------------------------------------------------------------
  */
 int
-TclXOSGetCloseOnExec (interp, channel, valuePtr)
-    Tcl_Interp *interp;
-    Tcl_Channel channel;
-    int        *valuePtr;
+TclXOSGetCloseOnExec (Tcl_Interp *interp,
+                      Tcl_Channel channel,
+                      int        *valuePtr)
 {
     HANDLE handle;
     tclXwinFileType type;
@@ -1756,10 +1744,9 @@ TclXOSGetCloseOnExec (interp, channel, valuePtr)
  *-----------------------------------------------------------------------------
  */
 int
-TclXOSSetCloseOnExec (interp, channel, value)
-    Tcl_Interp *interp;
-    Tcl_Channel channel;
-    int         value;
+TclXOSSetCloseOnExec (Tcl_Interp *interp,
+                      Tcl_Channel channel,
+                      int         value)
 {
     HANDLE handle;
     tclXwinFileType type;


### PR DESCRIPTION
This should resolve most `-Wdeprecated-non-prototype` (which newer clang enables by default) and `-Wstrict-prototypes` warnings. Remaining instances include those inherited from older autoconf and #19.