### PR TITLE
Fix `TclX_AppendObjResult()` calls with missing or uncast `NULL` terminators

### DIFF
--- a/generic/tclXsignal.c
+++ b/generic/tclXsignal.c
@@ -485,7 +485,7 @@ BlockSignals (Tcl_Interp *interp, int action, unsigned char signals[MAXSIG])
 #else
     TclX_AppendObjResult (interp,
                           "Posix signals are not available on this system, ",
-                          "can not block signals");
+                          "can not block signals", (char *) NULL);
     return TCL_ERROR;
 #endif
 }

--- a/generic/tclXsignal.c
+++ b/generic/tclXsignal.c
@@ -1328,7 +1328,7 @@ TclX_SignalObjCmd (ClientData   clientData,
             restart = TRUE;
         } else {
             TclX_AppendObjResult(interp, "invalid option \"", argStr,
-                                 "\", expected -restart", NULL);
+                                 "\", expected -restart", (char *) NULL);
             return TCL_ERROR;
         }
         firstArg++;
@@ -1342,7 +1342,7 @@ TclX_SignalObjCmd (ClientData   clientData,
 #ifdef NO_SIG_RESTART
     if (restart) {
         TclX_AppendObjResult(interp, "restarting of system calls from signals is not available on this system",
-                             NULL);
+                             (char *) NULL);
         return TCL_ERROR;
     }
 #endif

--- a/generic/tclXutil.c
+++ b/generic/tclXutil.c
@@ -787,7 +787,7 @@ TclX_WrongArgs (Tcl_Interp *interp, Tcl_Obj *commandNameObj, char *string)
  *
  * Parameters:
  *   o interp - Interpreter to set the result in.
- *   o args - Strings to append, terminated by a NULL.
+ *   o args - Strings to append, terminated by (char *)NULL.
  *-----------------------------------------------------------------------------
  */
 void

--- a/unix/tclXunixOS.c
+++ b/unix/tclXunixOS.c
@@ -1494,7 +1494,8 @@ TclXOSFunlock (Tcl_Interp *interp, TclX_FlockInfo *lockInfoPtr)
     if (stat < 0) {
         TclX_AppendObjResult (interp, "lock of \"",
                               Tcl_GetChannelName (lockInfoPtr->channel),
-                              "\" failed: ", Tcl_PosixError (interp));
+                              "\" failed: ", Tcl_PosixError (interp),
+                              (char *) NULL);
         return TCL_ERROR;
     }
 


### PR DESCRIPTION
Also revise comment documenting `TclX_AppendObjResult()` to use `(char *)NULL`.