### PR TITLE
Remove `TCL_VARARGS_DEF`/`TCL_VARARGS_START` usage

### DIFF
--- a/generic/tclExtend.h
+++ b/generic/tclExtend.h
@@ -97,7 +97,7 @@ EXTERN void	TclX_SplitWinCmdLine (int *argcPtr, char ***argvPtr);
 /*
  * Exported utility functions.
  */
-EXTERN void	TclX_AppendObjResult TCL_VARARGS_DEF(Tcl_Interp *, interpArg);
+EXTERN void	TclX_AppendObjResult (Tcl_Interp *interp, ...);
 
 EXTERN char *	TclX_DownShift (char *targetStr, CONST char *sourceStr);
 

--- a/generic/tclXutil.c
+++ b/generic/tclXutil.c
@@ -791,14 +791,12 @@ TclX_WrongArgs (Tcl_Interp *interp, Tcl_Obj *commandNameObj, char *string)
  *-----------------------------------------------------------------------------
  */
 void
-TclX_AppendObjResult TCL_VARARGS_DEF (Tcl_Interp *, arg1)
+TclX_AppendObjResult (Tcl_Interp *interp, ...)
 {
-    Tcl_Interp *interp;
     Tcl_Obj *resultPtr;
     va_list argList;
     char *string;
 
-    interp = TCL_VARARGS_START (Tcl_Interp *, arg1, argList);
     resultPtr = Tcl_GetObjResult (interp);
 
     if (Tcl_IsShared(resultPtr)) {
@@ -806,7 +804,7 @@ TclX_AppendObjResult TCL_VARARGS_DEF (Tcl_Interp *, arg1)
         Tcl_SetObjResult(interp, resultPtr);
     }
 
-    TCL_VARARGS_START(Tcl_Interp *,arg1,argList);
+    va_start(argList, interp);
     while (1) {
         string = va_arg(argList, char *);
         if (string == NULL) {


### PR DESCRIPTION
The `TCL_VARARGS_DEF` and `TCL_VARARGS_START` macros have been deprecated since Tcl 8.5 and are to be removed in Tcl 9.0.

#12 included something similar to this.