### PR TITLE
Enable `-Wsentinel` warnings for `TclX_AppendObjResult()`

### DIFF
--- a/generic/tclExtend.h
+++ b/generic/tclExtend.h
@@ -97,6 +97,10 @@ EXTERN void	TclX_SplitWinCmdLine (int *argcPtr, char ***argvPtr);
 /*
  * Exported utility functions.
  */
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+__attribute__((sentinel))
+#endif
 EXTERN void	TclX_AppendObjResult TCL_VARARGS_DEF(Tcl_Interp *, interpArg);
 
 EXTERN char *	TclX_DownShift (char *targetStr, CONST char *sourceStr);


### PR DESCRIPTION
`__attribute__((sentinel))` allows GCC ≥4.0 and Clang to emit warnings (by default) for calls to a variadic function without the required `NULL` terminator. Example LLVM.org Clang 17 warnings for instances fixed by #21:
```
./generic/tclXsignal.c:488:50: warning: missing sentinel in function call [-Wsentinel]
  488 |                           "can not block signals");
      |                                                  ^
      |                                                  , NULL
```
```
./unix/tclXunixOS.c:1497:69: warning: missing sentinel in function call [-Wsentinel]
 1497 |                               "\" failed: ", Tcl_PosixError (interp));
      |                                                                     ^
      |                                                                     , NULL
```

This warning (as phrased by Clang 17) does not suggest casting `NULL` to the appropriate pointer type for portability, but maybe it is still better than no warning at all.