### PR TITLE
configure: regenerate

### DIFF
--- a/configure
+++ b/configure
@@ -2342,7 +2342,7 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
-FULL_VERSION="8.6.1"
+FULL_VERSION="8.6.2"
 
 
     # TEA extensions pass this us the version of TEA they think they
@@ -9075,7 +9075,8 @@ else
 
 	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-#include <time.h>
+#include <stdlib.h>
+            #include <time.h>
 int
 main ()
 {
@@ -9111,7 +9112,8 @@ else
 
 	    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-#include <time.h>
+#include <stdlib.h>
+                #include <time.h>
 int
 main ()
 {
@@ -9196,10 +9198,11 @@ else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
+#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/times.h>
 #include <unistd.h>
-main() {
+int main(void) {
     struct tms cpu;
     times(&cpu);
     sleep(2);
@@ -9462,6 +9465,17 @@ else
 
 fi
 
+    for ac_func in rresvport
+do :
+  ac_fn_c_check_func "$LINENO" "rresvport" "ac_cv_func_rresvport"
+if test "x$ac_cv_func_rresvport" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_RRESVPORT 1
+_ACEOF
+
+fi
+done
+
 
     #-------------------------------------------------------------------------
     # Check for additional libraries the Tcl/Tk does not check for.
@@ -9524,7 +9538,8 @@ if test "x$ac_cv_func_catgets" = xyes; then :
 $as_echo_n "checking catclose return value... " >&6; }
     	 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-#include <nl_types.h>
+#include <stdlib.h>
+         #include <nl_types.h>
 int
 main ()
 {


### PR DESCRIPTION
Pick up configure.in and tcl.m4 changes from db8f0de, #18, and #15

(The autoconf 2.70 `--runstatedir` option added by b12cc8c is kept.)