### PR TITLE
Migrate `CONST` usage to `const`

### DIFF
--- a/generic/tclExtdInt.h
+++ b/generic/tclExtdInt.h
@@ -244,7 +244,7 @@ TclX_StructOffset (void *nsPtr, size_t offset,
 #define TclX_WriteNL(channel) (Tcl_Write (channel, "\n", 1))
 
 extern int
-TclX_StrToOffset (CONST char *string,
+TclX_StrToOffset (const char *string,
                   int         base,
                   off_t      *offsetPtr);
 

--- a/generic/tclExtend.h
+++ b/generic/tclExtend.h
@@ -99,16 +99,16 @@ EXTERN void	TclX_SplitWinCmdLine (int *argcPtr, char ***argvPtr);
  */
 EXTERN void	TclX_AppendObjResult TCL_VARARGS_DEF(Tcl_Interp *, interpArg);
 
-EXTERN char *	TclX_DownShift (char *targetStr, CONST char *sourceStr);
+EXTERN char *	TclX_DownShift (char *targetStr, const char *sourceStr);
 
-EXTERN int	TclX_StrToInt (CONST char *string, int base, int *intPtr);
+EXTERN int	TclX_StrToInt (const char *string, int base, int *intPtr);
 
-EXTERN int	TclX_StrToUnsigned (CONST char *string,
+EXTERN int	TclX_StrToUnsigned (const char *string,
                                 int	    base,
                                 unsigned   *unsignedPtr);
 
 EXTERN char *	TclX_UpShift (char	     *targetStr,
-                              CONST char *sourceStr);
+                              const char *sourceStr);
 
 /*
  * Exported keyed list object manipulation functions.
@@ -143,7 +143,7 @@ EXTERN void_pt	TclX_HandleAlloc (void_pt	headerPtr,
 EXTERN void	TclX_HandleFree (void_pt  headerPtr,
                              void_pt  entryPtr);
 
-EXTERN void_pt	TclX_HandleTblInit (CONST char *handleBase,
+EXTERN void_pt	TclX_HandleTblInit (const char *handleBase,
                                     int	    entrySize,
                                     int	    initEntries);
 
@@ -161,7 +161,7 @@ EXTERN void	TclX_WalkKeyToHandle (void_pt   headerPtr,
 
 EXTERN void_pt	TclX_HandleXlate (Tcl_Interp  *interp,
                                   void_pt	  headerPtr,
-                                  CONST  char *handle);
+                                  const  char *handle);
 
 EXTERN void_pt	TclX_HandleXlateObj (Tcl_Interp    *interp,
                                      void_pt	       headerPtr,

--- a/generic/tclXbsearch.c
+++ b/generic/tclXbsearch.c
@@ -52,7 +52,7 @@ static int
 TclX_BsearchObjCmd (ClientData clientData, 
                     Tcl_Interp *interp,
                     int objc,
-                    Tcl_Obj *CONST objv[]);
+                    Tcl_Obj *const objv[]);
 
 /*-----------------------------------------------------------------------------
  *
@@ -296,7 +296,7 @@ static int
 TclX_BsearchObjCmd (ClientData clientData,
                     Tcl_Interp *interp,
                     int objc,
-                    Tcl_Obj *CONST objv[])
+                    Tcl_Obj *const objv[])
 {
     int status;
     binSearchCB_t searchCB;

--- a/generic/tclXchmod.c
+++ b/generic/tclXchmod.c
@@ -39,19 +39,19 @@ static int
 TclX_ChmodObjCmd (ClientData clientData, 
                   Tcl_Interp *interp,
                   int objc,
-                  Tcl_Obj *CONST objv[]);
+                  Tcl_Obj *const objv[]);
 
 static int 
 TclX_ChownObjCmd (ClientData clientData, 
                   Tcl_Interp *interp,
                   int objc,
-                  Tcl_Obj *CONST objv[]);
+                  Tcl_Obj *const objv[]);
 
 static int 
 TclX_ChgrpObjCmd (ClientData clientData, 
                   Tcl_Interp *interp,
                   int objc,
-                  Tcl_Obj *CONST objv[]);
+                  Tcl_Obj *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -306,7 +306,7 @@ ChmodFileIdObj (Tcl_Interp *interp, modeInfo_t modeInfo, Tcl_Obj *fileIdObj)
  *-----------------------------------------------------------------------------
  */
 static int
-TclX_ChmodObjCmd (ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+TclX_ChmodObjCmd (ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     int           objIdx, idx, fileObjc, fileIds, result;
     modeInfo_t    modeInfo;
@@ -371,7 +371,7 @@ TclX_ChmodObjCmd (ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *
  *-----------------------------------------------------------------------------
  */
 static int
-TclX_ChownObjCmd (ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+TclX_ChownObjCmd (ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     int        objIdx, ownerObjc, fileIds;
     Tcl_Obj  **ownerObjv = NULL;
@@ -455,7 +455,7 @@ TclX_ChownObjCmd (ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *
  *-----------------------------------------------------------------------------
  */
 static int
-TclX_ChgrpObjCmd (ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+TclX_ChgrpObjCmd (ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     int        objIdx, fileIds;
     char      *fileIdsSwitch, *groupString;

--- a/generic/tclXcmdloop.c
+++ b/generic/tclXcmdloop.c
@@ -72,7 +72,7 @@ static int
 TclX_CommandloopObjCmd (ClientData clientData, 
                         Tcl_Interp *interp,
                         int objc,
-                        Tcl_Obj *CONST objv[]);
+                        Tcl_Obj *const objv[]);
 
 /*-----------------------------------------------------------------------------
  * IsSetVarCmd --
@@ -665,7 +665,7 @@ TclX_CommandLoop (Tcl_Interp *interp,
  *-----------------------------------------------------------------------------
  */
 static int
-TclX_CommandloopObjCmd (ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+TclX_CommandloopObjCmd (ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     int options = 0, async = FALSE, argIdx, interactive;
     char *argStr,  *endCommand = NULL;

--- a/generic/tclXcoalesce.c
+++ b/generic/tclXcoalesce.c
@@ -29,7 +29,7 @@
  *-----------------------------------------------------------------------------
  */
 static int
-TclX_CoalesceObjCmd (ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+TclX_CoalesceObjCmd (ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     int i;
     Tcl_Obj *val;

--- a/generic/tclXdebug.c
+++ b/generic/tclXdebug.c
@@ -90,7 +90,7 @@ static int
 TclX_CmdtraceObjCmd (ClientData clientData, 
                      Tcl_Interp *interp,
                      int objc,
-                     Tcl_Obj *CONST objv[]);
+                     Tcl_Obj *const objv[]);
 
 static void
 DebugCleanUp (ClientData  clientData,
@@ -387,7 +387,7 @@ static int
 TclX_CmdtraceObjCmd (ClientData clientData,
                      Tcl_Interp *interp,
                      int objc,
-                     Tcl_Obj *CONST objv[])
+                     Tcl_Obj *const objv[])
 {
     traceInfo_pt  infoPtr = (traceInfo_pt) clientData;
     int idx;

--- a/generic/tclXdup.c
+++ b/generic/tclXdup.c
@@ -34,7 +34,7 @@ static int
 TclX_DupObjCmd (ClientData   clientData,
                 Tcl_Interp  *interp,
                 int          objc,
-                Tcl_Obj     *CONST objv[]);
+                Tcl_Obj     *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -193,7 +193,7 @@ static int
 TclX_DupObjCmd (ClientData clientData,
                 Tcl_Interp *interp,
                 int objc,
-                Tcl_Obj *CONST objv[])
+                Tcl_Obj *const objv[])
 {
     Tcl_Channel newChannel;
     int bindFnum, fnum;

--- a/generic/tclXfcntl.c
+++ b/generic/tclXfcntl.c
@@ -85,7 +85,7 @@ static int
 TclX_FcntlObjCmd (ClientData clientData, 
                   Tcl_Interp *interp,
                   int objc,
-                  Tcl_Obj *CONST objv[]);
+                  Tcl_Obj *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -279,7 +279,7 @@ static int
 TclX_FcntlObjCmd (ClientData clientData,
                   Tcl_Interp *interp,
                   int objc,
-                  Tcl_Obj *CONST objv[])
+                  Tcl_Obj *const objv[])
 {
     Tcl_Channel  channel;
     int          mode;

--- a/generic/tclXfilecmds.c
+++ b/generic/tclXfilecmds.c
@@ -39,19 +39,19 @@ static int
 TclX_PipeObjCmd (ClientData  clientData,
                  Tcl_Interp *interp,
                  int         objc,
-                 Tcl_Obj    *CONST objv[]);
+                 Tcl_Obj    *const objv[]);
 
 static int
 TclX_FtruncateObjCmd (ClientData  clientData, 
                       Tcl_Interp *interp, 
                       int         objc,
-                      Tcl_Obj    *CONST objv[]);
+                      Tcl_Obj    *const objv[]);
 
 static int
 TclX_ReaddirObjCmd (ClientData clientData,
                     Tcl_Interp *interp,
                     int         objc,
-                    Tcl_Obj    *CONST objv[]);
+                    Tcl_Obj    *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -67,7 +67,7 @@ static int
 TclX_PipeObjCmd (ClientData  clientData,
                  Tcl_Interp *interp,
                  int         objc,
-                 Tcl_Obj    *CONST objv[])
+                 Tcl_Obj    *const objv[])
 {
     Tcl_Channel   channels [2];
     const char *channelNames [2];
@@ -160,7 +160,7 @@ static int
 TclX_FtruncateObjCmd (ClientData clientData,
                       Tcl_Interp *interp,
                       int objc,
-                      Tcl_Obj *CONST objv[])
+                      Tcl_Obj *const objv[])
 {
     int           objIdx, fileIds;
     off_t         newSize;
@@ -247,7 +247,7 @@ static int
 TclX_ReaddirObjCmd (ClientData clientData,
                     Tcl_Interp *interp,
                     int objc,
-                    Tcl_Obj *CONST objv[])
+                    Tcl_Obj *const objv[])
 {
     Tcl_DString  pathBuf;
     char        *dirPath;

--- a/generic/tclXfilescan.c
+++ b/generic/tclXfilescan.c
@@ -84,13 +84,13 @@ static int
 TclX_ScancontextObjCmd (ClientData  clientData,
                         Tcl_Interp *interp,
                         int         objc,
-                        Tcl_Obj    *CONST objv[]);
+                        Tcl_Obj    *const objv[]);
 
 static int
 TclX_ScanmatchObjCmd (ClientData  clientData,
                       Tcl_Interp *interp,
                       int         objc,
-                      Tcl_Obj    *CONST objv[]);
+                      Tcl_Obj    *const objv[]);
 
 static void
 CopyFileCloseHandler (ClientData clientData);
@@ -119,7 +119,7 @@ static int
 TclX_ScanfileObjCmd (ClientData  clientData,
                      Tcl_Interp *interp,
                      int         objc,
-                     Tcl_Obj    *CONST objv[]);
+                     Tcl_Obj    *const objv[]);
 
 static void
 FileScanCleanUp (ClientData  clientData,
@@ -331,7 +331,7 @@ static int
 TclX_ScancontextObjCmd (ClientData clientData,
                         Tcl_Interp *interp,
                         int objc,
-                        Tcl_Obj *CONST objv[])
+                        Tcl_Obj *const objv[])
 {
     char *subCommand;
 
@@ -393,7 +393,7 @@ TclX_ScancontextObjCmd (ClientData clientData,
 static int
 TclX_ScanmatchObjCmd (ClientData clientData,
                       Tcl_Interp *interp,
-                      int objc, Tcl_Obj *CONST objv[])
+                      int objc, Tcl_Obj *const objv[])
 {
     scanContext_t  *contextPtr, **tableEntryPtr;
     matchDef_t     *newmatch;
@@ -776,7 +776,7 @@ static int
 TclX_ScanfileObjCmd (ClientData clientData,
                      Tcl_Interp *interp,
                      int objc,
-                     Tcl_Obj *CONST objv[])
+                     Tcl_Obj *const objv[])
 {
     scanContext_t *contextPtr, **tableEntryPtr;
     Tcl_Obj       *contextHandleObj, *fileHandleObj, *copyFileHandleObj;

--- a/generic/tclXflock.c
+++ b/generic/tclXflock.c
@@ -25,7 +25,7 @@
 static int
 ParseLockUnlockArgs (Tcl_Interp     *interp,
                      int             objc,
-                     Tcl_Obj *CONST  objv[],
+                     Tcl_Obj *const  objv[],
                      int             argIdx,
                      TclX_FlockInfo *lockInfoPtr);
 
@@ -33,13 +33,13 @@ static int
 TclX_FlockObjCmd (ClientData clientData, 
                   Tcl_Interp *interp,
                   int         objc,
-                  Tcl_Obj    *CONST objv[]);
+                  Tcl_Obj    *const objv[]);
 
 static int
 TclX_FunlockObjCmd (ClientData clientData, 
                      Tcl_Interp *interp,
                      int         objc,
-                     Tcl_Obj    *CONST objv[]);
+                     Tcl_Obj    *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -66,7 +66,7 @@ TclX_FunlockObjCmd (ClientData clientData,
 static int
 ParseLockUnlockArgs (Tcl_Interp     *interp,
                      int             objc,
-                     Tcl_Obj *CONST  objv[],
+                     Tcl_Obj *const  objv[],
                      int             argIdx,
                      TclX_FlockInfo *lockInfoPtr)
 {
@@ -124,7 +124,7 @@ static int
 TclX_FlockObjCmd (ClientData clientData, 
                   Tcl_Interp *interp,
                   int         objc,
-                  Tcl_Obj    *CONST objv[])
+                  Tcl_Obj    *const objv[])
 {
     int argIdx;
     TclX_FlockInfo lockInfo;
@@ -208,7 +208,7 @@ static int
 TclX_FunlockObjCmd (ClientData clientData, 
                      Tcl_Interp *interp,
                      int         objc,
-                     Tcl_Obj    *CONST objv[])
+                     Tcl_Obj    *const objv[])
 {
     TclX_FlockInfo lockInfo;
 

--- a/generic/tclXfstat.c
+++ b/generic/tclXfstat.c
@@ -74,7 +74,7 @@ static int
 TclX_FstatObjCmd (ClientData clientData, 
                   Tcl_Interp *interp,
                   int objc,
-                  Tcl_Obj *CONST objv[]);
+                  Tcl_Obj *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -316,7 +316,7 @@ static int
 TclX_FstatObjCmd (ClientData clientData, 
                   Tcl_Interp *interp,
                   int objc,
-                  Tcl_Obj *CONST objv[])
+                  Tcl_Obj *const objv[])
 {
     Tcl_Channel channel;
     struct stat statBuf;

--- a/generic/tclXgeneral.c
+++ b/generic/tclXgeneral.c
@@ -33,19 +33,19 @@ static int
 TclX_EchoObjCmd (ClientData clientData, 
                  Tcl_Interp *interp,
                  int         objc,
-                 Tcl_Obj    *CONST objv[]);
+                 Tcl_Obj    *const objv[]);
 
 static int 
 TclX_InfoxObjCmd (ClientData clientData, 
                   Tcl_Interp *interp,
                   int         objc,
-                  Tcl_Obj    *CONST objv[]);
+                  Tcl_Obj    *const objv[]);
 
 static int 
 TclX_LoopObjCmd (ClientData clientData, 
                  Tcl_Interp *interp,
                  int         objc,
-                 Tcl_Obj    *CONST objv[]);
+                 Tcl_Obj    *const objv[]);
 
 static int
 SetLoopCounter (Tcl_Interp *interp,
@@ -59,7 +59,7 @@ static int
 TclX_Try_EvalObjCmd (ClientData clientData, 
                      Tcl_Interp *interp,
                      int         objc,
-                     Tcl_Obj    *CONST objv[]);
+                     Tcl_Obj    *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -119,7 +119,7 @@ static int
 TclX_EchoObjCmd (ClientData dummy,
                  Tcl_Interp *interp,
                  int objc,
-                 Tcl_Obj *CONST objv[])
+                 Tcl_Obj *const objv[])
 {
     int	  idx;
     Tcl_Channel channel;
@@ -164,7 +164,7 @@ static int
 TclX_InfoxObjCmd (ClientData clientData,
                   Tcl_Interp *interp,
                   int objc,
-                  Tcl_Obj *CONST objv[])
+                  Tcl_Obj *const objv[])
 {
     Tcl_Obj *resultPtr = Tcl_GetObjResult (interp);
     char *optionPtr;
@@ -353,7 +353,7 @@ static int
 TclX_LoopObjCmd (ClientData dummy,
                  Tcl_Interp *interp,
                  int objc,
-                 Tcl_Obj *CONST objv[])
+                 Tcl_Obj *const objv[])
 {
     int result = TCL_OK;
     long idx, first, limit, incr = 1;
@@ -484,7 +484,7 @@ static int
 TclX_Try_EvalObjCmd (ClientData  dummy,
                      Tcl_Interp *interp,
                      int         objc,
-                     Tcl_Obj *CONST objv[])
+                     Tcl_Obj *const objv[])
 {
     int code, code2;
     int haveFinally;

--- a/generic/tclXhandles.c
+++ b/generic/tclXhandles.c
@@ -102,12 +102,12 @@ AllocEntry (tblHeader_pt  tblHdrPtr,
 static int
 HandleDecodeObj (Tcl_Interp   *interp,
                  tblHeader_pt  tblHdrPtr,
-                 CONST char   *handle);
+                 const char   *handle);
 
 static int
 HandleDecode (Tcl_Interp   *interp,
               tblHeader_pt  tblHdrPtr,
-              CONST char   *handle);
+              const char   *handle);
 
 
 /*=============================================================================
@@ -221,7 +221,7 @@ AllocEntry (tblHeader_pt  tblHdrPtr,
  *-----------------------------------------------------------------------------
  */
 static int
-HandleDecode (Tcl_Interp *interp, tblHeader_pt tblHdrPtr, CONST char *handle)
+HandleDecode (Tcl_Interp *interp, tblHeader_pt tblHdrPtr, const char *handle)
 {
     unsigned entryIdx;
 
@@ -255,7 +255,7 @@ HandleDecode (Tcl_Interp *interp, tblHeader_pt tblHdrPtr, CONST char *handle)
 static int
 HandleDecodeObj (Tcl_Interp   *interp,
                  tblHeader_pt  tblHdrPtr,
-                 CONST char   *handle)
+                 const char   *handle)
 {
     unsigned entryIdx;
 
@@ -284,7 +284,7 @@ HandleDecodeObj (Tcl_Interp   *interp,
  *-----------------------------------------------------------------------------
  */
 void_pt
-TclX_HandleTblInit (CONST char *handleBase, int entrySize, int initEntries)
+TclX_HandleTblInit (const char *handleBase, int entrySize, int initEntries)
 {
     tblHeader_pt tblHdrPtr;
     int          baseLength = strlen ((char *) handleBase);
@@ -407,7 +407,7 @@ TclX_HandleAlloc (void_pt headerPtr, char *handlePtr)
  *-----------------------------------------------------------------------------
  */
 void_pt
-TclX_HandleXlate (Tcl_Interp *interp, void_pt headerPtr, CONST char *handle)
+TclX_HandleXlate (Tcl_Interp *interp, void_pt headerPtr, const char *handle)
 {
     tblHeader_pt   tblHdrPtr = (tblHeader_pt)headerPtr;
     entryHeader_pt entryHdrPtr;

--- a/generic/tclXkeylist.c
+++ b/generic/tclXkeylist.c
@@ -145,25 +145,25 @@ static int
 TclX_KeylgetObjCmd (ClientData   clientData,
                     Tcl_Interp  *interp,
                     int	     objc,
-                    Tcl_Obj	    *CONST objv[]);
+                    Tcl_Obj	    *const objv[]);
 
 static int
 TclX_KeylsetObjCmd (ClientData   clientData,
                     Tcl_Interp  *interp,
                     int	     objc,
-                    Tcl_Obj	    *CONST objv[]);
+                    Tcl_Obj	    *const objv[]);
 
 static int 
 TclX_KeyldelObjCmd (ClientData   clientData,
                     Tcl_Interp  *interp,
                     int	     objc,
-                    Tcl_Obj	    *CONST objv[]);
+                    Tcl_Obj	    *const objv[]);
 
 static int 
 TclX_KeylkeysObjCmd (ClientData   clientData,
                      Tcl_Interp  *interp,
                      int	      objc,
-                     Tcl_Obj     *CONST objv[]);
+                     Tcl_Obj     *const objv[]);
 
 /*
  * Type definition.
@@ -1008,7 +1008,7 @@ static int
 TclX_KeylgetObjCmd (ClientData      clientData,
                     Tcl_Interp     *interp,
                     int             objc,
-                    Tcl_Obj *CONST objv[])
+                    Tcl_Obj *const objv[])
 {
     Tcl_Obj *keylPtr, *valuePtr;
     char *key;
@@ -1086,7 +1086,7 @@ static int
 TclX_KeylsetObjCmd (ClientData     clientData,
                     Tcl_Interp    *interp,
                     int            objc,
-                    Tcl_Obj *CONST objv[])
+                    Tcl_Obj *const objv[])
 {
     Tcl_Obj *keylVarPtr, *newVarObj;
     char *key;
@@ -1145,7 +1145,7 @@ static int
 TclX_KeyldelObjCmd (ClientData  clientData,
                     Tcl_Interp *interp,
                     int         objc,
-                    Tcl_Obj    *CONST objv[])
+                    Tcl_Obj    *const objv[])
 {
     Tcl_Obj *keylVarPtr, *keylPtr;
     char *key;
@@ -1206,7 +1206,7 @@ static int
 TclX_KeylkeysObjCmd (ClientData   clientData,
                      Tcl_Interp  *interp,
                      int          objc,
-                     Tcl_Obj     *CONST objv[])
+                     Tcl_Obj     *const objv[])
 {
     Tcl_Obj *keylPtr, *listObjPtr;
     char *key;

--- a/generic/tclXlgets.c
+++ b/generic/tclXlgets.c
@@ -57,7 +57,7 @@ static int
 TclX_LgetsObjCmd (ClientData  clientData, 
                  Tcl_Interp  *interp, 
                  int          objc,
-                 Tcl_Obj     *CONST objv[]);
+                 Tcl_Obj     *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -409,7 +409,7 @@ static int
 TclX_LgetsObjCmd (ClientData  clientData, 
                  Tcl_Interp  *interp, 
                  int          objc,
-                 Tcl_Obj     *CONST objv[])
+                 Tcl_Obj     *const objv[])
 {
     Tcl_Channel channel;
     ReadData readData;

--- a/generic/tclXlib.c
+++ b/generic/tclXlib.c
@@ -127,19 +127,19 @@ static int
 TclX_load_tndxsObjCmd (ClientData  clientData,
                        Tcl_Interp *interp,
                        int         objc,
-                       Tcl_Obj    *CONST objv[]);
+                       Tcl_Obj    *const objv[]);
                                    
 static int
 TclX_Auto_load_pkgObjCmd (ClientData clientData, 
                           Tcl_Interp *interp,
                           int objc,
-                          Tcl_Obj *CONST objv[]);
+                          Tcl_Obj *const objv[]);
 
 static int
 TclX_LoadlibindexObjCmd (ClientData clientData, 
                          Tcl_Interp *interp,
                          int objc,
-                         Tcl_Obj *CONST objv[]);
+                         Tcl_Obj *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -855,7 +855,7 @@ static int
 TclX_load_tndxsObjCmd (ClientData  clientData,
                        Tcl_Interp *interp,
                        int         objc,
-                       Tcl_Obj    *CONST objv[])
+                       Tcl_Obj    *const objv[])
 {
     char *dirname;
 
@@ -879,7 +879,7 @@ static int
 TclX_Auto_load_pkgObjCmd (ClientData clientData, 
                           Tcl_Interp *interp,
                           int objc,
-                          Tcl_Obj *CONST objv[])
+                          Tcl_Obj *const objv[])
 {
     char     *fileName;
     off_t     offset;
@@ -915,7 +915,7 @@ static int
 TclX_LoadlibindexObjCmd (ClientData clientData, 
                          Tcl_Interp *interp,
                          int objc,
-                         Tcl_Obj *CONST objv[])
+                         Tcl_Obj *const objv[])
 {
     char        *pathName;
     Tcl_DString  pathNameBuf;

--- a/generic/tclXlist.c
+++ b/generic/tclXlist.c
@@ -26,43 +26,43 @@ static int
 TclX_LvarcatObjCmd (ClientData   clientData,
                     Tcl_Interp  *interp,
                     int          objc,
-                    Tcl_Obj     *CONST objv[]);
+                    Tcl_Obj     *const objv[]);
 
 static int
 TclX_LvarpopObjCmd (ClientData   clientData,
                     Tcl_Interp  *interp,
                     int          objc,
-                    Tcl_Obj    *CONST objv[]);
+                    Tcl_Obj    *const objv[]);
 
 static int
 TclX_LvarpushObjCmd (ClientData   clientData,
                      Tcl_Interp  *interp,
                      int          objc,
-                     Tcl_Obj    *CONST objv[]);
+                     Tcl_Obj    *const objv[]);
 
 static int
 TclX_LemptyObjCmd (ClientData   clientData,
                    Tcl_Interp  *interp,
                    int          objc,
-                   Tcl_Obj    *CONST objv[]);
+                   Tcl_Obj    *const objv[]);
 
 static int
 TclX_LassignObjCmd (ClientData   clientData,
                     Tcl_Interp  *interp,
                     int          objc,
-                    Tcl_Obj    *CONST objv[]);
+                    Tcl_Obj    *const objv[]);
 
 static int
 TclX_LmatchObjCmd (ClientData   clientData,
                    Tcl_Interp  *interp,
                    int          objc,
-                   Tcl_Obj    *CONST objv[]);
+                   Tcl_Obj    *const objv[]);
 
 static int
 TclX_LcontainObjCmd (ClientData   clientData,
                      Tcl_Interp  *interp,
                      int          objc,
-                     Tcl_Obj    *CONST objv[]);
+                     Tcl_Obj    *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -75,7 +75,7 @@ static int
 TclX_LvarcatObjCmd (ClientData   clientData,
                     Tcl_Interp  *interp,
                     int          objc,
-                    Tcl_Obj     *CONST objv[])
+                    Tcl_Obj     *const objv[])
 {
     Tcl_Obj *varObjPtr, *newObjPtr;
     int catObjc, idx, argIdx;
@@ -138,7 +138,7 @@ static int
 TclX_LvarpopObjCmd (ClientData   clientData,
                     Tcl_Interp  *interp,
                     int          objc,
-                    Tcl_Obj    *CONST objv[])
+                    Tcl_Obj    *const objv[])
 {
     Tcl_Obj *listVarPtr, *newVarObj, *returnElemPtr = NULL;
     int listIdx, listLen;
@@ -233,7 +233,7 @@ static int
 TclX_LvarpushObjCmd (ClientData   clientData,
                      Tcl_Interp  *interp,
                      int          objc,
-                     Tcl_Obj    *CONST objv[])
+                     Tcl_Obj    *const objv[])
 {
     Tcl_Obj *listVarPtr, *newVarObj;
     int listIdx, listLen;
@@ -304,7 +304,7 @@ static int
 TclX_LemptyObjCmd (ClientData   clientData,
                    Tcl_Interp  *interp,
                    int          objc,
-                   Tcl_Obj    *CONST objv[])
+                   Tcl_Obj    *const objv[])
 {
     int length;
 
@@ -343,7 +343,7 @@ static int
 TclX_LassignObjCmd (ClientData   clientData,
                     Tcl_Interp  *interp,
                     int          objc,
-                    Tcl_Obj    *CONST objv[])
+                    Tcl_Obj    *const objv[])
 {
     int listObjc, listIdx, idx, remaining;
     Tcl_Obj **listObjv, *elemPtr, *remainingObjPtr;
@@ -405,7 +405,7 @@ static int
 TclX_LmatchObjCmd (ClientData   clientData,
                    Tcl_Interp  *interp,
                    int          objc,
-                   Tcl_Obj    *CONST objv[])
+                   Tcl_Obj    *const objv[])
 {
 #define EXACT   0
 #define GLOB    1
@@ -502,7 +502,7 @@ static int
 TclX_LcontainObjCmd (ClientData   clientData,
                      Tcl_Interp  *interp,
                      int          objc,
-                     Tcl_Obj    *CONST objv[])
+                     Tcl_Obj    *const objv[])
 {
     int listObjc, idx;
     Tcl_Obj **listObjv;

--- a/generic/tclXmath.c
+++ b/generic/tclXmath.c
@@ -56,12 +56,12 @@ static long	ReallyRandom (long my_range);
 static int	TclX_MaxObjCmd (ClientData clientData,
                             Tcl_Interp *interp,
                             int         objc,
-                            Tcl_Obj    *CONST objv[]);
+                            Tcl_Obj    *const objv[]);
 
 static int	TclX_MinObjCmd (ClientData  clientData,
                             Tcl_Interp *interp,
                             int         objc,
-                            Tcl_Obj    *CONST objv[]);
+                            Tcl_Obj    *const objv[]);
 
 static int	TclX_MinMaxFunc (ClientData   clientData,
                              Tcl_Interp  *interp,
@@ -71,7 +71,7 @@ static int	TclX_MinMaxFunc (ClientData   clientData,
 static int	TclX_RandomObjCmd (ClientData  clientData,
                                Tcl_Interp *interp,
 				               int         objc,
-                               Tcl_Obj     *CONST objv[]);
+                               Tcl_Obj     *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -126,7 +126,7 @@ static int	ConvertIntOrDoubleObj (Tcl_Interp *interp,
 static int	TclX_MaxObjCmd (ClientData clientData,
                             Tcl_Interp *interp,
                             int         objc,
-                            Tcl_Obj    *CONST objv[])
+                            Tcl_Obj    *const objv[])
 {
     double value, maxValue = -MAXDOUBLE;
     int idx, maxIdx = 1;
@@ -158,7 +158,7 @@ static int	TclX_MaxObjCmd (ClientData clientData,
 static int	TclX_MinObjCmd (ClientData  clientData,
                             Tcl_Interp *interp,
                             int         objc,
-                            Tcl_Obj    *CONST objv[])
+                            Tcl_Obj    *const objv[])
 {
     double value, minValue = MAXDOUBLE;
     int idx, minIdx   = 1;
@@ -279,7 +279,7 @@ ReallyRandom (long myRange)
 static int	TclX_RandomObjCmd (ClientData  clientData,
                                Tcl_Interp *interp,
 				               int         objc,
-                               Tcl_Obj     *CONST objv[])
+                               Tcl_Obj     *const objv[])
 {
     long range;
     char *seedString;

--- a/generic/tclXmsgcat.c
+++ b/generic/tclXmsgcat.c
@@ -36,25 +36,25 @@ ParseFailOptionObj (Tcl_Interp *interp,
 
 static int
 CatOpFailedObj (Tcl_Interp *interp,
-                CONST char *errorMsg);
+                const char *errorMsg);
 
 static int
 TclX_CatopenObjCmd (ClientData  clientData,
                     Tcl_Interp *interp,
                     int         objc,
-                    Tcl_Obj   *CONST objv[]);
+                    Tcl_Obj   *const objv[]);
 
 static int
 TclX_CatgetsObjCmd (ClientData  clientData,
                     Tcl_Interp *interp,
                     int         objc,
-                    Tcl_Obj   *CONST objv[]);
+                    Tcl_Obj   *const objv[]);
 
 static int
 TclX_CatcloseObjCmd (ClientData  clientData,
                      Tcl_Interp *interp,
                      int         objc,
-                     Tcl_Obj   *CONST objv[]);
+                     Tcl_Obj   *const objv[]);
 
 static void
 MsgCatCleanUp (ClientData  clientData,
@@ -147,7 +147,7 @@ ParseFailOptionObj (Tcl_Interp *interp,
  */
 static int
 CatOpFailedObj (Tcl_Interp *interp,
-                CONST char *errorMsg)
+                const char *errorMsg)
 {
 #ifndef NO_CATGETS
     TclX_AppendObjResult (interp, errorMsg, (char *) NULL);
@@ -172,7 +172,7 @@ static int
 TclX_CatopenObjCmd (ClientData  clientData,
                     Tcl_Interp *interp,
                     int         objc,
-                    Tcl_Obj   *CONST objv[])
+                    Tcl_Obj   *const objv[])
 {
     int      fail;
     nl_catd  catDesc;
@@ -212,7 +212,7 @@ static int
 TclX_CatgetsObjCmd (ClientData  clientData,
                     Tcl_Interp *interp,
                     int         objc,
-                    Tcl_Obj   *CONST objv[])
+                    Tcl_Obj   *const objv[])
 {
     nl_catd   *catDescPtr;
     int       msgSetNum, msgNum;
@@ -267,7 +267,7 @@ static int
 TclX_CatcloseObjCmd (ClientData  clientData,
                      Tcl_Interp *interp,
                      int         objc,
-                     Tcl_Obj   *CONST objv[])
+                     Tcl_Obj   *const objv[])
 {
     int          fail;
     nl_catd     *catDescPtr;

--- a/generic/tclXoscmds.c
+++ b/generic/tclXoscmds.c
@@ -23,43 +23,43 @@ static int
 TclX_AlarmObjCmd (ClientData clientData,
                   Tcl_Interp *interp,
                   int objc,
-                  Tcl_Obj *CONST objv[]);
+                  Tcl_Obj *const objv[]);
 
 static int 
 TclX_LinkObjCmd (ClientData clientData,
                  Tcl_Interp *interp,
                  int objc,
-                 Tcl_Obj *CONST objv[]);
+                 Tcl_Obj *const objv[]);
 
 static int 
 TclX_NiceObjCmd (ClientData clientData,
                  Tcl_Interp *interp,
                  int objc,
-                 Tcl_Obj *CONST objv[]);
+                 Tcl_Obj *const objv[]);
 
 static int 
 TclX_SleepObjCmd (ClientData clientData,
                   Tcl_Interp *interp,
                   int objc,
-                  Tcl_Obj *CONST objv[]);
+                  Tcl_Obj *const objv[]);
 
 static int 
 TclX_SyncObjCmd (ClientData clientData,
                  Tcl_Interp *interp,
                  int objc,
-                 Tcl_Obj *CONST objv[]);
+                 Tcl_Obj *const objv[]);
 
 static int 
 TclX_SystemObjCmd (ClientData clientData,
                    Tcl_Interp *interp,
                    int objc,
-                   Tcl_Obj *CONST objv[]);
+                   Tcl_Obj *const objv[]);
 
 static int 
 TclX_UmaskObjCmd (ClientData clientData,
                   Tcl_Interp *interp,
                   int objc,
-                  Tcl_Obj *CONST objv[]);
+                  Tcl_Obj *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -76,7 +76,7 @@ static int
 TclX_AlarmObjCmd (ClientData clientData,
                   Tcl_Interp *interp,
                   int objc,
-                  Tcl_Obj *CONST objv[])
+                  Tcl_Obj *const objv[])
 {
     double seconds;
 
@@ -106,7 +106,7 @@ static int
 TclX_LinkObjCmd (ClientData clientData,
                  Tcl_Interp *interp,
                  int objc,
-                 Tcl_Obj *CONST objv[])
+                 Tcl_Obj *const objv[])
 {
     char *srcPath, *destPath;
     Tcl_DString  srcPathBuf, destPathBuf;
@@ -175,7 +175,7 @@ static int
 TclX_NiceObjCmd (ClientData clientData,
                  Tcl_Interp *interp,
                  int objc,
-                 Tcl_Obj *CONST objv[])
+                 Tcl_Obj *const objv[])
 {
     Tcl_Obj    *resultPtr = Tcl_GetObjResult (interp);
     int         priorityIncr, priority;
@@ -224,7 +224,7 @@ static int
 TclX_SleepObjCmd (ClientData clientData,
                   Tcl_Interp *interp,
                   int objc,
-                  Tcl_Obj *CONST objv[])
+                  Tcl_Obj *const objv[])
 {
     double time;
 
@@ -252,7 +252,7 @@ static int
 TclX_SyncObjCmd (ClientData clientData,
                  Tcl_Interp *interp,
                  int objc,
-                 Tcl_Obj *CONST objv[])
+                 Tcl_Obj *const objv[])
 {
     Tcl_Channel  channel;
 
@@ -286,7 +286,7 @@ static int
 TclX_SystemObjCmd (ClientData clientData,
                    Tcl_Interp *interp,
                    int objc,
-                   Tcl_Obj *CONST objv[])
+                   Tcl_Obj *const objv[])
 {
     Tcl_Obj *cmdObjPtr;
     char *cmdStr;
@@ -321,7 +321,7 @@ static int
 TclX_UmaskObjCmd (ClientData clientData,
                   Tcl_Interp *interp,
                   int objc,
-                  Tcl_Obj *CONST objv[])
+                  Tcl_Obj *const objv[])
 {
     int    mask;
     char  *umaskString;

--- a/generic/tclXprocess.c
+++ b/generic/tclXprocess.c
@@ -32,19 +32,19 @@ static int
 TclX_ExeclObjCmd (ClientData clientData,
                   Tcl_Interp *interp,
                   int objc,
-                  Tcl_Obj *CONST objv[]);
+                  Tcl_Obj *const objv[]);
 
 static int 
 TclX_ForkObjCmd (ClientData clientData,
                  Tcl_Interp *interp,
                  int objc,
-                 Tcl_Obj *CONST objv[]);
+                 Tcl_Obj *const objv[]);
 
 static int 
 TclX_WaitObjCmd (ClientData clientData,
                  Tcl_Interp *interp,
                  int objc,
-                 Tcl_Obj *CONST objv[]);
+                 Tcl_Obj *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -57,7 +57,7 @@ static int
 TclX_ForkObjCmd (ClientData clientData,
                  Tcl_Interp *interp,
                  int objc,
-                 Tcl_Obj *CONST objv[])
+                 Tcl_Obj *const objv[])
 {
     if (objc != 1)
 	return TclX_WrongArgs (interp, objv [0], "");
@@ -75,7 +75,7 @@ static int
 TclX_ExeclObjCmd (ClientData clientData,
                   Tcl_Interp *interp,
                   int objc,
-                  Tcl_Obj *CONST objv[])
+                  Tcl_Obj *const objv[])
 {
 #define STATIC_ARG_SIZE   12
     char  *staticArgv [STATIC_ARG_SIZE];
@@ -163,7 +163,7 @@ static int
 TclX_WaitObjCmd (ClientData clientData,
                  Tcl_Interp *interp,
                  int objc,
-                 Tcl_Obj *CONST objv[])
+                 Tcl_Obj *const objv[])
 {
     int idx, options = 0, pgroup = FALSE;
     char *argStr;

--- a/generic/tclXprofile.c
+++ b/generic/tclXprofile.c
@@ -126,7 +126,7 @@ static int
 ProfObjCommandEval (ClientData    clientData,
                     Tcl_Interp   *interp,
                     int           objc,
-                    Tcl_Obj      *CONST objv[]);
+                    Tcl_Obj      *const objv[]);
 
 static Tcl_CmdObjTraceProc ProfTraceRoutine;
 
@@ -154,7 +154,7 @@ static int
 TclX_ProfileObjCmd (ClientData   clientData,
                     Tcl_Interp  *interp,
                     int          objc,
-                    Tcl_Obj    *CONST objv[]);
+                    Tcl_Obj    *const objv[]);
 
 static void
 ProfMonCleanUp (ClientData  clientData,
@@ -535,7 +535,7 @@ static int
 ProfObjCommandEval (ClientData    clientData,
                     Tcl_Interp   *interp,
                     int           objc,
-                    Tcl_Obj      *CONST objv[])
+                    Tcl_Obj      *const objv[])
 {
     profInfo_t *infoPtr = (profInfo_t *) clientData;
     int isProc, result;
@@ -562,7 +562,7 @@ ProfTraceRoutine (ClientData  clientData,
                   const char *command,
                   Tcl_Command cmd,
                   int         objc,
-                  Tcl_Obj    *CONST objv[])
+                  Tcl_Obj    *const objv[])
 {
     /* struct Tcl_Obj * const *objv; */
     profInfo_t *infoPtr = (profInfo_t *) clientData;
@@ -802,7 +802,7 @@ static int
 TclX_ProfileObjCmd (ClientData   clientData,
                     Tcl_Interp  *interp,
                     int          objc,
-                    Tcl_Obj    *CONST objv[])
+                    Tcl_Obj    *const objv[])
 {
     profInfo_t *infoPtr = (profInfo_t *) clientData;
     int argIdx;

--- a/generic/tclXselect.c
+++ b/generic/tclXselect.c
@@ -80,7 +80,7 @@ static int
 TclX_SelectObjCmd (ClientData clientData, 
                    Tcl_Interp *interp,
                    int objc,
-                   Tcl_Obj *CONST objv[]);
+                   Tcl_Obj *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -275,7 +275,7 @@ static int
 TclX_SelectObjCmd (ClientData clientData, 
                    Tcl_Interp *interp,
                    int objc,
-                   Tcl_Obj *CONST objv[])
+                   Tcl_Obj *const objv[])
 {
     static int chanAccess [] = {TCL_READABLE, TCL_WRITABLE, 0};
     int idx;
@@ -406,7 +406,7 @@ TclX_SelectObjCmd (clientData, interp, objc, objv)
     ClientData   clientData;
     Tcl_Interp  *interp;
     int          objc;
-    Tcl_Obj     *CONST objv[]
+    Tcl_Obj     *const objv[]
 {
     Tcl_AppendResult(interp, Tcl_GetString(objv[0]),
 	    " is not available on this OS", (char *) NULL);

--- a/generic/tclXsignal.c
+++ b/generic/tclXsignal.c
@@ -52,7 +52,7 @@
  * Value returned by Tcl_SignalId when an invalid signal is passed in.
  * Pointer is used as a quick check of a valid signal number.
  */
-static CONST char *unknownSignalIdMsg;
+static const char *unknownSignalIdMsg;
 
 /*
  * Signal name table maps name to number.  Note, it is possible to have
@@ -327,13 +327,13 @@ static int
 TclX_SignalObjCmd (ClientData   clientData,
                    Tcl_Interp  *interp,
                    int          objc,
-                   Tcl_Obj     *CONST objv[]);
+                   Tcl_Obj     *const objv[]);
 
 static int
 TclX_KillObjCmd (ClientData   clientData,
                  Tcl_Interp  *interp,
                  int          objc,
-                 Tcl_Obj     *CONST objv[]);
+                 Tcl_Obj     *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -1311,7 +1311,7 @@ static int
 TclX_SignalObjCmd (ClientData   clientData,
                    Tcl_Interp  *interp,
                    int          objc,
-                   Tcl_Obj     *CONST objv[])
+                   Tcl_Obj     *const objv[])
 {
     unsigned char signals [MAXSIG];
     char *argStr, *actionStr;
@@ -1451,7 +1451,7 @@ static int
 TclX_KillObjCmd (ClientData   clientData,
                  Tcl_Interp  *interp,
                  int          objc,
-                 Tcl_Obj     *CONST objv[])
+                 Tcl_Obj     *const objv[])
 {
     int    signalNum, nextArg, idx, procId, procObjc;
     int    pgroup = FALSE;

--- a/generic/tclXsocket.c
+++ b/generic/tclXsocket.c
@@ -28,13 +28,13 @@ ReturnGetHostError (Tcl_Interp *interp,
 static struct hostent *
 InfoGetHost (Tcl_Interp *interp,
              int         objc,
-             Tcl_Obj   *CONST objv[]);
+             Tcl_Obj   *const objv[]);
 
 static int
 TclX_HostInfoObjCmd (ClientData  clientData,
                     Tcl_Interp *interp,
                     int         objc,
-                    Tcl_Obj   *CONST objv[]);
+                    Tcl_Obj   *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -106,7 +106,7 @@ TclXGetHostInfo (Tcl_Interp *interp, Tcl_Channel channel, int remoteHost)
 {
     struct sockaddr_in sockaddr;
     struct hostent *hostEntry;
-    CONST char *hostName;
+    const char *hostName;
     Tcl_Obj *listObjv [3];
 
     if (remoteHost) {
@@ -150,7 +150,7 @@ TclXGetHostInfo (Tcl_Interp *interp, Tcl_Channel channel, int remoteHost)
  *-----------------------------------------------------------------------------
  */
 static struct hostent *
-InfoGetHost (Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+InfoGetHost (Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     struct hostent *hostEntry;
     struct in_addr address;
@@ -194,7 +194,7 @@ static int
 TclX_HostInfoObjCmd (ClientData  clientData,
                     Tcl_Interp *interp,
                     int         objc,
-                    Tcl_Obj   *CONST objv[])
+                    Tcl_Obj   *const objv[])
 {
     struct hostent *hostEntry;
     struct in_addr  inAddr;

--- a/generic/tclXstring.c
+++ b/generic/tclXstring.c
@@ -40,61 +40,61 @@ static int
 TclX_CindexObjCmd (ClientData clientData,
                    Tcl_Interp *interp,
                    int         objc,
-                   Tcl_Obj   *CONST objv[]);
+                   Tcl_Obj   *const objv[]);
 
 static int 
 TclX_ClengthObjCmd (ClientData clientData,
                     Tcl_Interp *interp,
                     int         objc,
-                    Tcl_Obj   *CONST objv[]);
+                    Tcl_Obj   *const objv[]);
 
 static int
 TclX_CconcatObjCmd (ClientData clientData,
                     Tcl_Interp *interp,
                     int         objc,
-                    Tcl_Obj   *CONST objv[]);
+                    Tcl_Obj   *const objv[]);
 
 static int 
 TclX_CrangeObjCmd (ClientData clientData,
                    Tcl_Interp *interp,
                    int         objc,
-                   Tcl_Obj   *CONST objv[]);
+                   Tcl_Obj   *const objv[]);
 
 static int 
 TclX_CcollateObjCmd (ClientData clientData,
                      Tcl_Interp *interp,
                      int         objc,
-                     Tcl_Obj   *CONST objv[]);
+                     Tcl_Obj   *const objv[]);
 
 static int 
 TclX_ReplicateObjCmd (ClientData clientData,
                       Tcl_Interp *interp,
                       int         objc,
-                      Tcl_Obj   *CONST objv[]);
+                      Tcl_Obj   *const objv[]);
 
 static int 
 TclX_TranslitObjCmd (ClientData clientData,
                      Tcl_Interp *interp,
                      int         objc,
-                     Tcl_Obj   *CONST objv[]);
+                     Tcl_Obj   *const objv[]);
 
 static int 
 TclX_CtypeObjCmd (ClientData clientData,
                   Tcl_Interp *interp,
                   int         objc,
-                  Tcl_Obj   *CONST objv[]);
+                  Tcl_Obj   *const objv[]);
 
 static int 
 TclX_CtokenObjCmd (ClientData clientData,
                    Tcl_Interp *interp,
                    int         objc,
-                   Tcl_Obj   *CONST objv[]);
+                   Tcl_Obj   *const objv[]);
 
 static int 
 TclX_CequalObjCmd (ClientData clientData,
                    Tcl_Interp *interp,
                    int         objc,
-                   Tcl_Obj   *CONST objv[]);
+                   Tcl_Obj   *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -110,7 +110,7 @@ static int
 TclX_CindexObjCmd (ClientData clientData,
                    Tcl_Interp *interp,
                    int         objc,
-                   Tcl_Obj   *CONST objv[])
+                   Tcl_Obj   *const objv[])
 {
     int strLen, utfLen, idx, numBytes;
     char *str, buf [TCL_UTF_MAX];
@@ -147,7 +147,7 @@ static int
 TclX_ClengthObjCmd (ClientData clientData,
                     Tcl_Interp *interp,
                     int         objc,
-                    Tcl_Obj   *CONST objv[])
+                    Tcl_Obj   *const objv[])
 {
     char *str;
     int strLen;
@@ -174,7 +174,7 @@ static int
 TclX_CconcatObjCmd (ClientData clientData,
                     Tcl_Interp *interp,
                     int         objc,
-                    Tcl_Obj   *CONST objv[])
+                    Tcl_Obj   *const objv[])
 {
     Tcl_Obj *resultPtr = Tcl_GetObjResult(interp);
     int idx, strLen;
@@ -203,7 +203,7 @@ static int
 TclX_CrangeObjCmd (ClientData clientData,
                    Tcl_Interp *interp,
                    int         objc,
-                   Tcl_Obj   *CONST objv[])
+                   Tcl_Obj   *const objv[])
 {
     int strLen, utfLen, first, subLen;
     size_t isRange = (size_t) clientData;
@@ -262,7 +262,7 @@ static int
 TclX_CcollateObjCmd (ClientData clientData,
                      Tcl_Interp *interp,
                      int         objc,
-                     Tcl_Obj   *CONST objv[])
+                     Tcl_Obj   *const objv[])
 {
     int argIndex, result, local = FALSE;
     char *optionString;
@@ -323,7 +323,7 @@ static int
 TclX_ReplicateObjCmd (ClientData clientData,
                       Tcl_Interp *interp,
                       int         objc,
-                      Tcl_Obj   *CONST objv[])
+                      Tcl_Obj   *const objv[])
 {
     Tcl_Obj     *resultPtr = Tcl_GetObjResult (interp);
     long         count;
@@ -359,7 +359,7 @@ static int
 TclX_CtokenObjCmd (ClientData clientData,
                    Tcl_Interp *interp,
                    int         objc,
-                   Tcl_Obj   *CONST objv[])
+                   Tcl_Obj   *const objv[])
 {
     Tcl_Obj* stringVarObj;
     char* string;
@@ -439,7 +439,7 @@ static int
 TclX_CequalObjCmd (ClientData clientData,
                    Tcl_Interp *interp,
                    int         objc,
-                   Tcl_Obj   *CONST objv[])
+                   Tcl_Obj   *const objv[])
 {
     char *string1Ptr;
     int string1Len;
@@ -537,7 +537,7 @@ static int
 TclX_TranslitObjCmd (ClientData clientData,
                      Tcl_Interp *interp,
                      int         objc,
-                     Tcl_Obj   *CONST objv[])
+                     Tcl_Obj   *const objv[])
 {
     unsigned char from [MAX_EXPANSION+1];
     int           fromLen;
@@ -652,7 +652,7 @@ static int
 TclX_CtypeObjCmd (ClientData clientData,
                   Tcl_Interp *interp,
                   int         objc,
-                  Tcl_Obj   *CONST objv[])
+                  Tcl_Obj   *const objv[])
 {
     int failIndex = FALSE;
     char *optStr, *class, *charStr;

--- a/generic/tclXutil.c
+++ b/generic/tclXutil.c
@@ -58,7 +58,7 @@ char *tclXWrongArgs = "wrong # args: ";
  *-----------------------------------------------------------------------------
  */
 int
-TclX_StrToInt (CONST char *string, int base, int *intPtr)
+TclX_StrToInt (const char *string, int base, int *intPtr)
 {
     char *end, *p;
     int   i;
@@ -115,7 +115,7 @@ TclX_StrToInt (CONST char *string, int base, int *intPtr)
  *-----------------------------------------------------------------------------
  */
 int
-TclX_StrToUnsigned (CONST char *string, int base, unsigned *unsignedPtr)
+TclX_StrToUnsigned (const char *string, int base, unsigned *unsignedPtr)
 {
     char *end, *p;
     unsigned i;
@@ -158,7 +158,7 @@ TclX_StrToUnsigned (CONST char *string, int base, unsigned *unsignedPtr)
  *-----------------------------------------------------------------------------
  */
 int
-TclX_StrToOffset (CONST char *string, int base, off_t *offsetPtr)
+TclX_StrToOffset (const char *string, int base, off_t *offsetPtr)
 {
     char *end, *p;
     off_t i;
@@ -217,7 +217,7 @@ TclX_StrToOffset (CONST char *string, int base, off_t *offsetPtr)
  *-----------------------------------------------------------------------------
  */
 char *
-TclX_DownShift (char *targetStr, CONST char *sourceStr)
+TclX_DownShift (char *targetStr, const char *sourceStr)
 {
     register char theChar;
 
@@ -252,7 +252,7 @@ TclX_DownShift (char *targetStr, CONST char *sourceStr)
  *-----------------------------------------------------------------------------
  */
 char *
-TclX_UpShift (char *targetStr, CONST char *sourceStr)
+TclX_UpShift (char *targetStr, const char *sourceStr)
 {
     register char theChar;
 

--- a/unix/tclXchannelfd.c
+++ b/unix/tclXchannelfd.c
@@ -60,7 +60,7 @@ ChannelToFd (Tcl_Channel 		channel,
 }
 
 static int
-TclX_ChannelFdObjCmd (ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj*CONST objv[])
+TclX_ChannelFdObjCmd (ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj*const objv[])
 {
 	const char          *channelName;
 	Tcl_Channel	     channel;

--- a/unix/tclXunixCmds.c
+++ b/unix/tclXunixCmds.c
@@ -23,13 +23,13 @@ static int
 TclX_ChrootObjCmd (ClientData clientData,
                   Tcl_Interp *interp,
                   int         objc,
-			      Tcl_Obj     *CONST objv[]);
+			      Tcl_Obj     *const objv[]);
 
 static int
 TclX_TimesObjCmd (ClientData   clientData,
                  Tcl_Interp  *interp,
                  int          objc,
-                 Tcl_Obj      *CONST objv[]);
+                 Tcl_Obj      *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -46,7 +46,7 @@ static int
 TclX_ChrootObjCmd (ClientData clientData,
                   Tcl_Interp *interp,
                   int         objc,
-			      Tcl_Obj     *CONST objv[])
+			      Tcl_Obj     *const objv[])
 {
     char   *chrootString;
     int     chrootStrLen;
@@ -79,7 +79,7 @@ static int
 TclX_TimesObjCmd (ClientData   clientData,
                  Tcl_Interp  *interp,
                  int          objc,
-                 Tcl_Obj      *CONST objv[])
+                 Tcl_Obj      *const objv[])
 {
     struct tms tm;
     char       timesBuf [48];

--- a/unix/tclXunixId.c
+++ b/unix/tclXunixId.c
@@ -56,58 +56,58 @@ GroupnameToGroupidResult (Tcl_Interp *interp,
 static int
 IdConvert (Tcl_Interp *interp,
            int         objc,
-           Tcl_Obj   *CONST objv[]);
+           Tcl_Obj   *const objv[]);
 
 static int
 IdEffective  (Tcl_Interp  *interp,
               int          objc,
-              Tcl_Obj      *CONST objv[]);
+              Tcl_Obj      *const objv[]);
 
 static int
 IdProcess  (Tcl_Interp    *interp,
             int            objc,
-            Tcl_Obj      *CONST objv[]);
+            Tcl_Obj      *const objv[]);
 
 static int
 IdGroupids  (Tcl_Interp    *interp,
              int            objc,
-             Tcl_Obj      *CONST objv[],
+             Tcl_Obj      *const objv[],
              int         symbolic);
 
 static int
 IdHost (Tcl_Interp    *interp,
         int            objc,
-        Tcl_Obj      *CONST objv[]);
+        Tcl_Obj      *const objv[]);
 
 static int
 GetSetWrongArgs (Tcl_Interp    *interp,
-                 Tcl_Obj      *CONST objv[]);
+                 Tcl_Obj      *const objv[]);
 
 static int
 IdUser (Tcl_Interp    *interp,
         int            objc,
-        Tcl_Obj      *CONST objv[]);
+        Tcl_Obj      *const objv[]);
 
 static int
 IdUserId (Tcl_Interp    *interp,
           int            objc,
-          Tcl_Obj      *CONST objv[]);
+          Tcl_Obj      *const objv[]);
 
 static int
 IdGroup (Tcl_Interp    *interp,
          int            objc,
-         Tcl_Obj      *CONST objv[]);
+         Tcl_Obj      *const objv[]);
 
 static int
 IdGroupId (Tcl_Interp    *interp,
            int            objc,
-           Tcl_Obj      *CONST objv[]);
+           Tcl_Obj      *const objv[]);
 
 static int 
 TclX_IdObjCmd (ClientData clientData,
                Tcl_Interp *interp,
                int objc,
-               Tcl_Obj *CONST objv[]);
+               Tcl_Obj *const objv[]);
 
 /*-----------------------------------------------------------------------------
  * TclX_IdObjCmd --
@@ -231,7 +231,7 @@ GroupnameToGroupidResult (Tcl_Interp *interp, char *groupName)
  * id convert type value
  */
 static int
-IdConvert (Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+IdConvert (Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     long           uid;
     long           gid;
@@ -272,7 +272,7 @@ IdConvert (Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
  * id effective type
  */
 static int
-IdEffective (Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+IdEffective (Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     char          *subCommand;
 
@@ -307,7 +307,7 @@ IdEffective (Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
  * id process ?parent|group? ?set?
  */
 static int
-IdProcess (Tcl_Interp *interp, int objc, Tcl_Obj      *CONST objv[])
+IdProcess (Tcl_Interp *interp, int objc, Tcl_Obj      *const objv[])
 {
     pid_t          pid;
     char          *subCommand;
@@ -368,7 +368,7 @@ IdProcess (Tcl_Interp *interp, int objc, Tcl_Obj      *CONST objv[])
  * id groups
  */
 static int
-IdGroupids (Tcl_Interp *interp, int objc, Tcl_Obj*CONST objv[], int symbolic)
+IdGroupids (Tcl_Interp *interp, int objc, Tcl_Obj*const objv[], int symbolic)
 {
 #ifndef NO_GETGROUPS
     gid_t         *groups;
@@ -436,7 +436,7 @@ IdGroupids (Tcl_Interp *interp, int objc, Tcl_Obj*CONST objv[], int symbolic)
  * id host
  */
 static int
-IdHost (Tcl_Interp *interp, int objc, Tcl_Obj*CONST objv[])
+IdHost (Tcl_Interp *interp, int objc, Tcl_Obj*const objv[])
 {
 #ifndef NO_GETHOSTNAME
 #ifndef MAXHOSTNAMELEN
@@ -466,7 +466,7 @@ IdHost (Tcl_Interp *interp, int objc, Tcl_Obj*CONST objv[])
  * Return error when a get set function has too many args (2 or 3 expected).
  */
 static int
-GetSetWrongArgs (Tcl_Interp *interp, Tcl_Obj*CONST objv[])
+GetSetWrongArgs (Tcl_Interp *interp, Tcl_Obj*const objv[])
 {
     return TclX_WrongArgs (interp, objv [0], "arg ?value?");
 }
@@ -475,7 +475,7 @@ GetSetWrongArgs (Tcl_Interp *interp, Tcl_Obj*CONST objv[])
  * id user
  */
 static int
-IdUser (Tcl_Interp *interp, int objc, Tcl_Obj*CONST objv[])
+IdUser (Tcl_Interp *interp, int objc, Tcl_Obj*const objv[])
 {
     struct passwd *pw;
     char          *user;
@@ -511,7 +511,7 @@ IdUser (Tcl_Interp *interp, int objc, Tcl_Obj*CONST objv[])
  * id userid
  */
 static int
-IdUserId (Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+IdUserId (Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     int uid;
 
@@ -538,7 +538,7 @@ IdUserId (Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
  * id group
  */
 static int
-IdGroup (Tcl_Interp *interp, int objc, Tcl_Obj*CONST objv[])
+IdGroup (Tcl_Interp *interp, int objc, Tcl_Obj*const objv[])
 {
     struct group *grp;
     char         *groupName;
@@ -574,7 +574,7 @@ IdGroup (Tcl_Interp *interp, int objc, Tcl_Obj*CONST objv[])
  * id groupid
  */
 static int
-IdGroupId (Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+IdGroupId (Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     int gid;
     
@@ -598,7 +598,7 @@ IdGroupId (Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 }
 
 static int
-TclX_IdObjCmd (ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj*CONST objv[])
+TclX_IdObjCmd (ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj*const objv[])
 {
     char       *subCommand;
 

--- a/win/tclXwinCmds.c
+++ b/win/tclXwinCmds.c
@@ -23,13 +23,13 @@ static int
 TclX_ChrootObjCmd (ClientData clientData,
 				  Tcl_Interp *interp, 
 			      int         objc,
-			      Tcl_Obj     *CONST objv[]);
+			      Tcl_Obj     *const objv[]);
 
 static int 
 TclX_TimesObjCmd (ClientData   clientData,
 				 Tcl_Interp  *interp,
 				 int          objc,
-				 Tcl_Obj      *CONST objv[]);
+				 Tcl_Obj      *const objv[]);
 
 
 /*-----------------------------------------------------------------------------
@@ -41,7 +41,7 @@ static int
 TclX_ChrootObjCmd (ClientData  clientData,
                   Tcl_Interp *interp,
                   int         objc,
-                  Tcl_Obj   *CONST objv[])
+                  Tcl_Obj   *const objv[])
 {
     return TclXNotAvailableObjError (interp, objv [0]);
 }
@@ -55,7 +55,7 @@ static int
 TclX_TimesObjCmd (ClientData  clientData,
                  Tcl_Interp *interp,
                  int         objc,
-                 Tcl_Obj   *CONST objv[])
+                 Tcl_Obj   *const objv[])
 {
     return TclXNotAvailableObjError (interp, objv [0]);
 }

--- a/win/tclXwinId.c
+++ b/win/tclXwinId.c
@@ -24,18 +24,18 @@
 static int
 IdProcess  (Tcl_Interp *interp,
 			int objc,
-			Tcl_Obj *CONST objv[]);
+			Tcl_Obj *const objv[]);
 
 static int
 IdHost (Tcl_Interp *interp,
 		int objc,
-		Tcl_Obj *CONST objv[]);
+		Tcl_Obj *const objv[]);
 
 static int 
 TclX_IdObjCmd (ClientData clientData,
 			   Tcl_Interp *interp,
 			   int objc,
-			   Tcl_Obj *CONST objv[]);
+			   Tcl_Obj *const objv[]);
 
 /*-----------------------------------------------------------------------------
  * Tcl_IdCmd --
@@ -57,7 +57,7 @@ static int
 IdProcess (interp, objc, objv)
     Tcl_Interp *interp;
     int         objc;
-    Tcl_Obj    *CONST objv[];
+    Tcl_Obj    *const objv[];
 {
     Tcl_Obj *resultPtr = Tcl_GetObjResult (interp);
 
@@ -77,7 +77,7 @@ static int
 IdHost (interp, objc, objv)
     Tcl_Interp *interp;
     int         objc;
-    Tcl_Obj    *CONST objv[];
+    Tcl_Obj    *const objv[];
 {
     char hostName [TCL_RESULT_SIZE];
 
@@ -100,7 +100,7 @@ TclX_IdObjCmd (clientData, interp, objc, objv)
     ClientData  clientData;
     Tcl_Interp *interp;
     int         objc;
-    Tcl_Obj    *CONST objv[];
+    Tcl_Obj    *const objv[];
 {
     char *optionPtr;
 


### PR DESCRIPTION
This PR is meant for visibility, i.e. to avoid others proposing the same thing. The change is merely picked from the existing tcl87 branch (401c99705b5858d07748dc30e5e682916a9abf8b).

`CONST` (from tcl.h) was for compatibility with systems lacking `const`. It is to be deprecated in Tcl 8.7, and removed in Tcl 9.0.