### PR TITLE
Add const to match tclExtdInt.h TclXOSInetAtoN def

### DIFF
--- a/win/tclXwinOS.c
+++ b/win/tclXwinOS.c
@@ -1076,7 +1076,7 @@ TclXOSexecl (Tcl_Interp *interp,
  */
 int
 TclXOSInetAtoN (Tcl_Interp     *interp,
-                char           *strAddress,
+                const char     *strAddress,
                 struct in_addr *inAddress)
 {
     inAddress->s_addr = inet_addr (strAddress);


### PR DESCRIPTION
This patch fixes a compile error when building with MINGW64.